### PR TITLE
getById instead of email

### DIFF
--- a/src/LaravelHubspotServiceProvider.php
+++ b/src/LaravelHubspotServiceProvider.php
@@ -32,7 +32,7 @@ class LaravelHubspotServiceProvider extends PackageServiceProvider
     {
         $this->app->bind(LaravelHubspot::class, function ($app) {
 
-            $stack = new HandlerStack();
+            $stack = new HandlerStack;
             $stack->setHandler(Utils::chooseHandler());
 
             $stack->push(Middleware::mapRequest(function (RequestInterface $r) {

--- a/src/Models/HubspotContact.php
+++ b/src/Models/HubspotContact.php
@@ -76,14 +76,13 @@ trait HubspotContact
         // }
 
         try {
-            // TODO get by ID is unreliable (404 with api but works with web UI)
-            // if ($model->hubspot_id) {
-            // $hubspotContact = Hubspot::crm()->contacts()->basicApi()->getById($model->hubspot_id, null, null, null, false, 'id');
-            // } else {
-            $hubspotContact = Hubspot::crm()->contacts()->basicApi()->getById($model->email, null, null, null, false, 'email');
+            if ($model->hubspot_id) {
+                $hubspotContact = Hubspot::crm()->contacts()->basicApi()->getById($model->hubspot_id);
+            } else {
+                $hubspotContact = Hubspot::crm()->contacts()->basicApi()->getById($model->email, null, null, null, false, 'email');
 
-            $model->hubspot_id = $hubspotContact['id'];
-            // }
+                $model->hubspot_id = $hubspotContact['id'];
+            }
         } catch (ApiException $e) {
             // catch 404 error
             Log::debug('Hubspot contact not found. Creating', ['email' => $model->email]);


### PR DESCRIPTION
This allows user to change their email without creating an additional hubspot contact