### PR TITLE
return after company update exception

### DIFF
--- a/src/Models/HubspotContact.php
+++ b/src/Models/HubspotContact.php
@@ -55,6 +55,8 @@ trait HubspotContact
             $hubspotContact = Hubspot::crm()->contacts()->basicApi()->update($model->hubspot_id, $model->hubspotPropertiesObject($model->hubspotMap));
         } catch (ApiException $e) {
             Log::error('Hubspot contact update failed', ['email' => $model->email]);
+
+            return;
         }
 
         $hubspotCompany = $model->getRelationValue($model->hubspotCompanyRelation);


### PR DESCRIPTION
If an exception happens on the company update call, you cannot return that contact later, so return when error occurs. 