### PR TITLE
feat: restore updateOrCreateHubspotContact method for backward compatibility

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,6 +67,8 @@ The following methods have been **removed** from traits and should not be used:
 - `associateCompanyIfNeeded()`
 - `saveHubspotId()`
 
+**Note:** The `updateOrCreateHubspotContact()` method has been **restored** in v2.0.1 to maintain backward compatibility. This method now uses the new service architecture internally.
+
 **From HubspotCompany trait:**
 - `createHubspotCompany()`
 - `updateHubspotCompany()`
@@ -91,6 +93,17 @@ $contactService->createContact($data, User::class);
 
 // Update contact
 $contactService->updateContact($data);
+```
+
+#### 5. Backward Compatibility Method
+
+**The `updateOrCreateHubspotContact()` method is still available:**
+```php
+// This method still works in v2.0.1+
+$user->updateOrCreateHubspotContact();
+
+// It internally uses the new service architecture
+// and handles both create and update scenarios automatically
 ```
 
 ### Benefits of v2.0

--- a/tests/Unit/Models/HubspotContactTraitTest.php
+++ b/tests/Unit/Models/HubspotContactTraitTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Models\HubspotContact;
+use Tapp\LaravelHubspot\Services\HubspotContactService;
+
+// Create a test model that uses the trait
+class TestUserModel implements HubspotModelInterface
+{
+    use HubspotContact;
+
+    public $id = 1;
+
+    public $email = 'test@example.com';
+
+    public $first_name = 'John';
+
+    public $last_name = 'Doe';
+
+    public $hubspot_id = null;
+
+    public array $hubspotMap = [
+        'email' => 'email',
+        'firstname' => 'first_name',
+        'lastname' => 'last_name',
+    ];
+
+    public function getKey()
+    {
+        return $this->id;
+    }
+
+    public function getHubspotMap(): array
+    {
+        return $this->hubspotMap;
+    }
+
+    public function getHubspotUpdateMap(): array
+    {
+        return [];
+    }
+
+    public function getHubspotCompanyRelation(): ?string
+    {
+        return null;
+    }
+
+    public function getHubspotProperties(array $hubspotMap): array
+    {
+        return [];
+    }
+
+    public function getHubspotId(): ?string
+    {
+        return $this->hubspot_id;
+    }
+
+    public function setHubspotId(?string $hubspotId): void
+    {
+        $this->hubspot_id = $hubspotId;
+    }
+
+    public function getRelationValue(string $relation)
+    {
+        return null;
+    }
+}
+
+beforeEach(function () {
+    $this->model = new TestUserModel;
+});
+
+test('updateOrCreateHubspotContact calls createContact when no hubspot_id exists', function () {
+    $mockService = Mockery::mock(HubspotContactService::class);
+    $mockService->shouldReceive('createContact')
+        ->once()
+        ->with(Mockery::type('array'), TestUserModel::class)
+        ->andReturn(['id' => '12345', 'properties' => ['email' => 'test@example.com']]);
+
+    app()->instance(HubspotContactService::class, $mockService);
+
+    $result = $this->model->updateOrCreateHubspotContact();
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('12345');
+});
+
+test('updateOrCreateHubspotContact calls updateContact when hubspot_id exists', function () {
+    // Set hubspot_id on the model
+    $this->model->setHubspotId('12345');
+
+    $mockService = Mockery::mock(HubspotContactService::class);
+    $mockService->shouldReceive('updateContact')
+        ->once()
+        ->with(Mockery::type('array'))
+        ->andReturn(['id' => '12345', 'properties' => ['email' => 'test@example.com']]);
+
+    app()->instance(HubspotContactService::class, $mockService);
+
+    $result = $this->model->updateOrCreateHubspotContact();
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('12345');
+});
+
+test('updateOrCreateHubspotContact falls back to createContact when updateContact fails', function () {
+    // Set hubspot_id on the model
+    $this->model->setHubspotId('12345');
+
+    $mockService = Mockery::mock(HubspotContactService::class);
+    $mockService->shouldReceive('updateContact')
+        ->once()
+        ->with(Mockery::type('array'))
+        ->andThrow(new \Exception('Update failed'));
+
+    $mockService->shouldReceive('createContact')
+        ->once()
+        ->with(Mockery::type('array'), TestUserModel::class)
+        ->andReturn(['id' => '67890', 'properties' => ['email' => 'test@example.com']]);
+
+    app()->instance(HubspotContactService::class, $mockService);
+
+    $result = $this->model->updateOrCreateHubspotContact();
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('67890');
+});
+
+test('updateOrCreateHubspotContact includes all required data', function () {
+    $mockService = Mockery::mock(HubspotContactService::class);
+    $mockService->shouldReceive('createContact')
+        ->once()
+        ->with(Mockery::type('array'), TestUserModel::class)
+        ->andReturn(['id' => '12345', 'properties' => []]);
+
+    app()->instance(HubspotContactService::class, $mockService);
+
+    $result = $this->model->updateOrCreateHubspotContact();
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('12345');
+});


### PR DESCRIPTION
This PR restores the updateOrCreateHubspotContact method that was removed in v2 but is still being used in consuming applications like CHECK-LMS.

## Problem
The updateOrCreateHubspotContact method was removed in the v2 refactor but was not properly documented in the migration guide. This caused breaking changes for existing integrations.

## Solution
- Restored updateOrCreateHubspotContact method to HubspotContact trait
- Uses new service architecture internally for consistency with v2 design
- Maintains backward compatibility for existing integrations
- Updated migration guide to document the restored method
- Added comprehensive tests to ensure the method works correctly

## Implementation Details
The restored method:
- Attempts to update the contact if hubspot_id exists
- Falls back to creating a new contact if update fails or no hubspot_id exists
- Uses the new HubspotContactService internally
- Includes all required data (mapped fields, dynamic properties, company relations)
- Provides proper error handling and logging

## Testing
- All existing tests pass
- New tests cover all scenarios (create, update, fallback)
- Code style and static analysis pass
- Backward compatibility maintained

## Migration Impact
No breaking changes - existing code using updateOrCreateHubspotContact() will continue to work without modification.

Fixes the issue identified in the code review where CHECK-LMS was still calling the removed method in their listener.