### PR TITLE
Handle BackedEnum and UnitEnum in PropertyConverter

### DIFF
--- a/src/Commands/DebugHubspotData.php
+++ b/src/Commands/DebugHubspotData.php
@@ -2,7 +2,9 @@
 
 namespace Tapp\LaravelHubspot\Commands;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
 
 class DebugHubspotData extends Command
 {
@@ -25,7 +27,7 @@ class DebugHubspotData extends Command
      */
     public function handle(): int
     {
-        /** @var class-string<\Illuminate\Database\Eloquent\Model> $contactModel */
+        /** @var class-string<Model> $contactModel */
         $contactModel = $this->argument('model');
         $email = $this->option('email');
 
@@ -119,7 +121,7 @@ class DebugHubspotData extends Command
             }
 
             // Convert data types to strings for HubSpot API
-            if ($propertyValue instanceof \Carbon\Carbon) {
+            if ($propertyValue instanceof Carbon) {
                 $properties[$key] = $propertyValue->toISOString();
             } elseif (is_array($propertyValue)) {
                 if (empty($propertyValue)) {

--- a/src/Commands/SyncHubspotContacts.php
+++ b/src/Commands/SyncHubspotContacts.php
@@ -3,6 +3,7 @@
 namespace Tapp\LaravelHubspot\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
 
@@ -37,7 +38,7 @@ class SyncHubspotContacts extends Command
      */
     public function handle(): int
     {
-        /** @var class-string<\Illuminate\Database\Eloquent\Model> $contactModel */
+        /** @var class-string<Model> $contactModel */
         $contactModel = $this->argument('model');
         $delay = (int) $this->option('delay');
         $limit = $this->option('limit');
@@ -122,7 +123,7 @@ class SyncHubspotContacts extends Command
     /**
      * Prepare contact data for the service.
      */
-    protected function prepareContactData(\Illuminate\Database\Eloquent\Model $contact): array
+    protected function prepareContactData(Model $contact): array
     {
         $data = $contact->toArray();
 

--- a/src/Facades/Hubspot.php
+++ b/src/Facades/Hubspot.php
@@ -3,9 +3,10 @@
 namespace Tapp\LaravelHubspot\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Tapp\LaravelHubspot\LaravelHubspot;
 
 /**
- * @see \Tapp\LaravelHubspot\LaravelHubspot
+ * @see LaravelHubspot
  *
  * @method static \HubSpot\Discovery\Crm\Discovery crm()
  */
@@ -13,6 +14,6 @@ class Hubspot extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return \Tapp\LaravelHubspot\LaravelHubspot::class;
+        return LaravelHubspot::class;
     }
 }

--- a/src/Jobs/BaseHubspotJob.php
+++ b/src/Jobs/BaseHubspotJob.php
@@ -115,7 +115,7 @@ abstract class BaseHubspotJob implements ShouldQueue
             return;
         }
 
-        /** @var \Illuminate\Database\Eloquent\Model|null $model */
+        /** @var Model|null $model */
         $model = $this->modelClass::find($this->modelData['id'] ?? null);
         if ($model instanceof Model && method_exists($model, 'setHubspotId')) {
             $model->setHubspotId($hubspotId);

--- a/src/Jobs/SyncHubspotCompanyJob.php
+++ b/src/Jobs/SyncHubspotCompanyJob.php
@@ -3,6 +3,7 @@
 namespace Tapp\LaravelHubspot\Jobs;
 
 use HubSpot\Client\Crm\Companies\ApiException;
+use HubSpot\Client\Crm\Companies\Model\Error;
 use HubSpot\Client\Crm\Companies\Model\SimplePublicObjectInput as CompanyUpdateObject;
 use HubSpot\Client\Crm\Companies\Model\SimplePublicObjectInputForCreate as CompanyCreateObject;
 use Illuminate\Support\Facades\Log;
@@ -42,7 +43,7 @@ class SyncHubspotCompanyJob extends BaseHubspotJob
             $hubspotCompany = Hubspot::crm()->companies()->basicApi()->create($properties);
 
             // Check if response is an Error object
-            if ($hubspotCompany instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+            if ($hubspotCompany instanceof Error) {
                 throw new \Exception('HubSpot API returned an error: '.$hubspotCompany->getMessage());
             }
 
@@ -84,7 +85,7 @@ class SyncHubspotCompanyJob extends BaseHubspotJob
         );
 
         // Check if response is an Error object
-        if ($hubspotCompany instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+        if ($hubspotCompany instanceof Error) {
             throw new \Exception('HubSpot API returned an error: '.$hubspotCompany->getMessage());
         }
     }

--- a/src/LaravelHubspotServiceProvider.php
+++ b/src/LaravelHubspotServiceProvider.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Utils;
+use Illuminate\Support\Facades\Log;
 use Psr\Http\Message\RequestInterface;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -39,7 +40,7 @@ class LaravelHubspotServiceProvider extends PackageServiceProvider
             // Only initialize HubSpot client if API key is provided and not disabled
             if (! config('hubspot.api_key') || config('hubspot.disabled')) {
                 // Return a mock object that throws an exception when used
-                return new \Tapp\LaravelHubspot\MockHubspotClient;
+                return new MockHubspotClient;
             }
 
             $stack = new HandlerStack;
@@ -47,7 +48,7 @@ class LaravelHubspotServiceProvider extends PackageServiceProvider
 
             $stack->push(Middleware::mapRequest(function (RequestInterface $r) {
                 if (config('hubspot.log_requests')) {
-                    \Illuminate\Support\Facades\Log::info('Hubspot Request: '.$r->getMethod().' '.$r->getUri());
+                    Log::info('Hubspot Request: '.$r->getMethod().' '.$r->getUri());
                 }
 
                 return $r;

--- a/src/Models/HubspotContact.php
+++ b/src/Models/HubspotContact.php
@@ -3,6 +3,10 @@
 namespace Tapp\LaravelHubspot\Models;
 
 use HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate as ContactObject;
+use Illuminate\Support\Facades\Log;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Observers\HubspotContactObserver;
+use Tapp\LaravelHubspot\Services\HubspotContactService;
 use Tapp\LaravelHubspot\Services\PropertyConverter;
 use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
 
@@ -86,7 +90,7 @@ trait HubspotContact
             return;
         }
 
-        $observer = new \Tapp\LaravelHubspot\Observers\HubspotContactObserver;
+        $observer = new HubspotContactObserver;
         $operation = ! empty($this->getHubspotId()) ? 'update' : 'create';
         $observer->dispatchSyncJob($this, $operation);
     }
@@ -103,7 +107,7 @@ trait HubspotContact
      */
     public function updateOrCreateHubspotContact(): array
     {
-        $service = app(\Tapp\LaravelHubspot\Services\HubspotContactService::class);
+        $service = app(HubspotContactService::class);
 
         $data = [
             'id' => $this->getKey(),
@@ -131,7 +135,7 @@ trait HubspotContact
             if ($company) {
                 $data['hubspotCompanyRelation'] = [
                     'id' => $company->getKey(),
-                    'hubspot_id' => $company instanceof \Tapp\LaravelHubspot\Contracts\HubspotModelInterface ? $company->getHubspotId() : ($company->hubspot_id ?? null),
+                    'hubspot_id' => $company instanceof HubspotModelInterface ? $company->getHubspotId() : ($company->hubspot_id ?? null),
                     'name' => $company->name ?? $company->getAttribute('name'),
                 ];
             }
@@ -143,7 +147,7 @@ trait HubspotContact
                 return $service->updateContact($data);
             } catch (\Exception $e) {
                 // If update fails (e.g., invalid hubspot_id), try to create instead
-                \Illuminate\Support\Facades\Log::info('Update failed, attempting to create contact', [
+                Log::info('Update failed, attempting to create contact', [
                     'model_id' => $this->getKey(),
                     'hubspot_id' => $this->getHubspotId(),
                     'error' => $e->getMessage(),

--- a/src/Services/HubspotCompanyService.php
+++ b/src/Services/HubspotCompanyService.php
@@ -5,9 +5,11 @@ namespace Tapp\LaravelHubspot\Services;
 use HubSpot\Client\Crm\Associations\V4\ApiException as AssociationsApiException;
 use HubSpot\Client\Crm\Associations\V4\Model\AssociationSpec;
 use HubSpot\Client\Crm\Companies\ApiException as CompaniesApiException;
+use HubSpot\Client\Crm\Companies\Model\Error;
 use HubSpot\Client\Crm\Companies\Model\Filter;
 use HubSpot\Client\Crm\Companies\Model\FilterGroup;
 use HubSpot\Client\Crm\Companies\Model\PublicObjectSearchRequest as CompanySearch;
+use HubSpot\Client\Crm\Companies\Model\SimplePublicObjectInputForCreate;
 use Illuminate\Support\Facades\Log;
 use Tapp\LaravelHubspot\Facades\Hubspot;
 
@@ -98,11 +100,11 @@ class HubspotCompanyService
 
             // Try to create the company, handle duplicates gracefully
             try {
-                $companyInput = new \HubSpot\Client\Crm\Companies\Model\SimplePublicObjectInputForCreate(['properties' => $properties]);
+                $companyInput = new SimplePublicObjectInputForCreate(['properties' => $properties]);
                 $newCompany = Hubspot::crm()->companies()->basicApi()->create($companyInput);
 
                 // Check if response is an Error object
-                if ($newCompany instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+                if ($newCompany instanceof Error) {
                     throw new \Exception('HubSpot API returned an error: '.$newCompany->getMessage());
                 }
 
@@ -174,7 +176,7 @@ class HubspotCompanyService
             $searchResults = Hubspot::crm()->companies()->searchApi()->doSearch($companySearch);
 
             // Check if it's an error response
-            if ($searchResults instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+            if ($searchResults instanceof Error) {
                 throw new \Exception('HubSpot API returned an error: '.$searchResults->getMessage());
             }
 
@@ -215,7 +217,7 @@ class HubspotCompanyService
             $searchResults = Hubspot::crm()->companies()->searchApi()->doSearch($companySearch);
 
             // Check if it's an error response
-            if ($searchResults instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+            if ($searchResults instanceof Error) {
                 throw new \Exception('HubSpot API returned an error: '.$searchResults->getMessage());
             }
 
@@ -289,7 +291,7 @@ class HubspotCompanyService
                 $company = Hubspot::crm()->companies()->basicApi()->getById($companyId);
 
                 // Check if response is an Error object
-                if ($company instanceof \HubSpot\Client\Crm\Companies\Model\Error) {
+                if ($company instanceof Error) {
                     throw new \Exception('HubSpot API returned an error: '.$company->getMessage());
                 }
 

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -3,6 +3,7 @@
 namespace Tapp\LaravelHubspot\Services;
 
 use HubSpot\Client\Crm\Contacts\ApiException;
+use HubSpot\Client\Crm\Contacts\Model\Error;
 use HubSpot\Client\Crm\Contacts\Model\Filter as ContactFilter;
 use HubSpot\Client\Crm\Contacts\Model\FilterGroup as ContactFilterGroup;
 use HubSpot\Client\Crm\Contacts\Model\PublicObjectSearchRequest as ContactSearchRequest;
@@ -25,7 +26,7 @@ class HubspotContactService
             $hubspotContact = Hubspot::crm()->contacts()->basicApi()->create($properties);
 
             // Check if response is an Error object
-            if ($hubspotContact instanceof \HubSpot\Client\Crm\Contacts\Model\Error) {
+            if ($hubspotContact instanceof Error) {
                 throw new \Exception('HubSpot API returned an error: '.$hubspotContact->getMessage());
             }
 
@@ -165,7 +166,7 @@ class HubspotContactService
             );
 
             // Check if response is an Error object
-            if ($hubspotContact instanceof \HubSpot\Client\Crm\Contacts\Model\Error) {
+            if ($hubspotContact instanceof Error) {
                 throw new \Exception('HubSpot API returned an error: '.$hubspotContact->getMessage());
             }
         } catch (ApiException $e) {
@@ -225,7 +226,7 @@ class HubspotContactService
                 $contact = Hubspot::crm()->contacts()->basicApi()->getById($data['hubspot_id']);
 
                 // Check if response is an Error object
-                if ($contact instanceof \HubSpot\Client\Crm\Contacts\Model\Error) {
+                if ($contact instanceof Error) {
                     throw new \Exception('HubSpot API returned an error: '.$contact->getMessage());
                 }
 
@@ -267,7 +268,7 @@ class HubspotContactService
 
             $searchResults = Hubspot::crm()->contacts()->searchApi()->doSearch($searchRequest);
 
-            if ($searchResults instanceof \HubSpot\Client\Crm\Contacts\Model\Error) {
+            if ($searchResults instanceof Error) {
                 Log::warning('HubSpot contact search returned error', [
                     'email' => $email,
                     'error' => $searchResults->getMessage(),
@@ -462,7 +463,7 @@ class HubspotContactService
             return;
         }
 
-        /** @var \Illuminate\Database\Eloquent\Model|null $model */
+        /** @var Model|null $model */
         $model = $modelClass::find($modelId);
         if ($model instanceof Model && method_exists($model, 'setHubspotId')) {
             $model->setHubspotId($hubspotId);
@@ -589,7 +590,7 @@ class HubspotContactService
         $companyModelClass = str_replace('User', 'Agency', $modelClass);
 
         if (class_exists($companyModelClass)) {
-            /** @var \Illuminate\Database\Eloquent\Model|null $company */
+            /** @var Model|null $company */
             $company = $companyModelClass::find($modelId);
             if ($company instanceof Model && method_exists($company, 'setHubspotId')) {
                 $company->setHubspotId($hubspotId);

--- a/src/Services/PropertyConverter.php
+++ b/src/Services/PropertyConverter.php
@@ -31,6 +31,10 @@ class PropertyConverter
 
             // Handle regular indexed arrays
             return implode(', ', array_filter($value, 'is_scalar'));
+        } elseif ($value instanceof \BackedEnum) {
+            return (string) $value->value;
+        } elseif ($value instanceof \UnitEnum) {
+            return $value->name;
         } elseif (is_object($value)) {
             if (method_exists($value, '__toString')) {
                 return (string) $value;

--- a/src/Services/PropertyConverter.php
+++ b/src/Services/PropertyConverter.php
@@ -2,6 +2,8 @@
 
 namespace Tapp\LaravelHubspot\Services;
 
+use Carbon\Carbon;
+
 class PropertyConverter
 {
     /**
@@ -11,7 +13,7 @@ class PropertyConverter
     {
         if (is_null($value)) {
             return null;
-        } elseif ($value instanceof \Carbon\Carbon) {
+        } elseif ($value instanceof Carbon) {
             return $value->toISOString();
         } elseif (is_array($value)) {
             if (empty($value)) {

--- a/tests/Integration/HubspotApiIntegrationTest.php
+++ b/tests/Integration/HubspotApiIntegrationTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use HubSpot\Client\Crm\Contacts\Model\PublicObjectSearchRequest;
+use HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput;
+use Illuminate\Database\Eloquent\Model;
 use Tapp\LaravelHubspot\Facades\Hubspot;
 
 beforeEach(function () {
@@ -18,7 +21,7 @@ test('it can connect to hubspot api', function () {
             'lastname' => 'Connection',
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
         $result = Hubspot::crm()->contacts()->basicApi()->create($contactObject);
 
         expect($result)->not->toBeEmpty();
@@ -27,7 +30,7 @@ test('it can connect to hubspot api', function () {
         $contactId = is_array($result) ? $result['id'] : $result->getId();
         $this->cleanupTestContact($contactId);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to connect to HubSpot API: '.$e->getMessage());
     }
 });
@@ -47,7 +50,7 @@ test('it can create contact via service', function () {
             'lastname' => $testData['last_name'],
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
         $result = Hubspot::crm()->contacts()->basicApi()->create($contactObject);
 
         // Handle both array and object responses
@@ -60,7 +63,7 @@ test('it can create contact via service', function () {
         // Clean up - delete the test contact
         $this->cleanupTestContact($contactId);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to create contact: '.$e->getMessage());
     }
 });
@@ -89,7 +92,7 @@ test('it can create company via trait', function () {
         // Clean up - delete the test company
         $this->cleanupTestCompany($companyId);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to create company: '.$e->getMessage());
     }
 });
@@ -105,12 +108,12 @@ test('it can find contact by email', function () {
             'lastname' => 'Search',
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
         $createdContact = Hubspot::crm()->contacts()->basicApi()->create($contactObject);
         $contactId = is_array($createdContact) ? $createdContact['id'] : $createdContact->getId();
 
         // Now search for it
-        $searchRequest = new \HubSpot\Client\Crm\Contacts\Model\PublicObjectSearchRequest([
+        $searchRequest = new PublicObjectSearchRequest([
             'filterGroups' => [
                 [
                     'filters' => [
@@ -132,7 +135,7 @@ test('it can find contact by email', function () {
         // Clean up
         $this->cleanupTestContact($contactId);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to find contact by email: '.$e->getMessage());
     }
 });
@@ -148,7 +151,7 @@ test('it can update contact properties', function () {
             'lastname' => 'Name',
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
         $createdContact = Hubspot::crm()->contacts()->basicApi()->create($contactObject);
         $contactId = is_array($createdContact) ? $createdContact['id'] : $createdContact->getId();
 
@@ -158,7 +161,7 @@ test('it can update contact properties', function () {
             'lastname' => 'Name',
         ];
 
-        $updateObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $updateProperties]);
+        $updateObject = new SimplePublicObjectInput(['properties' => $updateProperties]);
         $updatedContact = Hubspot::crm()->contacts()->basicApi()->update($contactId, $updateObject);
 
         $updatedProperties = is_array($updatedContact) ? $updatedContact['properties'] : $updatedContact->getProperties();
@@ -169,7 +172,7 @@ test('it can update contact properties', function () {
         // Clean up
         $this->cleanupTestContact($contactId);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to update contact: '.$e->getMessage());
     }
 });
@@ -185,7 +188,7 @@ test('it can delete contact', function () {
             'lastname' => 'Delete',
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
         $createdContact = Hubspot::crm()->contacts()->basicApi()->create($contactObject);
         $contactId = is_array($createdContact) ? $createdContact['id'] : $createdContact->getId();
 
@@ -196,12 +199,12 @@ test('it can delete contact', function () {
         try {
             Hubspot::crm()->contacts()->basicApi()->getById($contactId);
             test()->fail('Contact should have been deleted');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Expected - contact should not exist
             expect($e->getMessage())->toContain('404');
         }
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         test()->fail('Failed to delete contact: '.$e->getMessage());
     }
 });
@@ -217,12 +220,12 @@ test('it handles invalid api key gracefully', function () {
             'lastname' => 'User',
         ];
 
-        $contactObject = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput(['properties' => $properties]);
+        $contactObject = new SimplePublicObjectInput(['properties' => $properties]);
 
         expect(fn () => Hubspot::crm()->contacts()->basicApi()->create($contactObject))
-            ->toThrow(\Exception::class);
+            ->toThrow(Exception::class);
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         // Expected - should throw an exception with invalid API key
         expect($e->getMessage())->toContain('401');
     }
@@ -233,7 +236,7 @@ function cleanupTestContact($contactId)
 {
     try {
         Hubspot::crm()->contacts()->basicApi()->archive($contactId);
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         // Ignore cleanup errors
     }
 }
@@ -242,13 +245,13 @@ function cleanupTestCompany($companyId)
 {
     try {
         Hubspot::crm()->companies()->basicApi()->archive($companyId);
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         // Ignore cleanup errors
     }
 }
 
 // Test model class for integration tests
-class TestCompany extends \Illuminate\Database\Eloquent\Model
+class TestCompany extends Model
 {
     protected $fillable = ['name', 'domain'];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,13 +4,14 @@ namespace Tapp\LaravelHubspot\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Tapp\LaravelHubspot\LaravelHubspotServiceProvider;
 
 class TestCase extends Orchestra
 {
     /**
-     * @var \Illuminate\Testing\TestResponse|null
+     * @var TestResponse|null
      */
     public static $latestResponse;
 

--- a/tests/Unit/Commands/DebugHubspotDataTest.php
+++ b/tests/Unit/Commands/DebugHubspotDataTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Illuminate\Console\Command;
 use Tapp\LaravelHubspot\Commands\DebugHubspotData;
 
 test('it has correct signature', function () {
     $command = new DebugHubspotData;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $signatureProperty = $reflection->getProperty('signature');
     $signatureProperty->setAccessible(true);
 
@@ -13,7 +14,7 @@ test('it has correct signature', function () {
 
 test('it has correct description', function () {
     $command = new DebugHubspotData;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $descriptionProperty = $reflection->getProperty('description');
     $descriptionProperty->setAccessible(true);
 
@@ -23,5 +24,5 @@ test('it has correct description', function () {
 test('it extends console command', function () {
     $command = new DebugHubspotData;
 
-    expect($command)->toBeInstanceOf(\Illuminate\Console\Command::class);
+    expect($command)->toBeInstanceOf(Command::class);
 });

--- a/tests/Unit/Commands/SyncHubspotContactsTest.php
+++ b/tests/Unit/Commands/SyncHubspotContactsTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Illuminate\Console\Command;
 use Tapp\LaravelHubspot\Commands\SyncHubspotContacts;
 
 test('it has correct signature', function () {
     $command = new SyncHubspotContacts;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $signatureProperty = $reflection->getProperty('signature');
     $signatureProperty->setAccessible(true);
 
@@ -15,7 +16,7 @@ test('it has correct signature', function () {
 
 test('it has correct description', function () {
     $command = new SyncHubspotContacts;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $descriptionProperty = $reflection->getProperty('description');
     $descriptionProperty->setAccessible(true);
 
@@ -24,7 +25,7 @@ test('it has correct description', function () {
 
 test('it has correct default options', function () {
     $command = new SyncHubspotContacts;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $signatureProperty = $reflection->getProperty('signature');
     $signatureProperty->setAccessible(true);
     $signature = $signatureProperty->getValue($command);
@@ -37,5 +38,5 @@ test('it has correct default options', function () {
 test('it extends console command', function () {
     $command = new SyncHubspotContacts;
 
-    expect($command)->toBeInstanceOf(\Illuminate\Console\Command::class);
+    expect($command)->toBeInstanceOf(Command::class);
 });

--- a/tests/Unit/Commands/SyncHubspotPropertiesTest.php
+++ b/tests/Unit/Commands/SyncHubspotPropertiesTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Illuminate\Console\Command;
 use Tapp\LaravelHubspot\Commands\SyncHubspotProperties;
 
 test('it has correct signature', function () {
     $command = new SyncHubspotProperties;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $signatureProperty = $reflection->getProperty('signature');
     $signatureProperty->setAccessible(true);
 
@@ -13,7 +14,7 @@ test('it has correct signature', function () {
 
 test('it has correct description', function () {
     $command = new SyncHubspotProperties;
-    $reflection = new \ReflectionClass($command);
+    $reflection = new ReflectionClass($command);
     $descriptionProperty = $reflection->getProperty('description');
     $descriptionProperty->setAccessible(true);
 
@@ -23,5 +24,5 @@ test('it has correct description', function () {
 test('it extends console command', function () {
     $command = new SyncHubspotProperties;
 
-    expect($command)->toBeInstanceOf(\Illuminate\Console\Command::class);
+    expect($command)->toBeInstanceOf(Command::class);
 });

--- a/tests/Unit/HubspotContactServiceTest.php
+++ b/tests/Unit/HubspotContactServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use HubSpot\Client\Crm\Contacts\Model\SimplePublicObject;
+use HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate;
 use Tapp\LaravelHubspot\Facades\Hubspot;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
 
@@ -22,13 +23,13 @@ test('it builds properties object correctly', function () {
     ];
 
     // Use reflection to test protected method
-    $reflection = new \ReflectionClass($this->service);
+    $reflection = new ReflectionClass($this->service);
     $method = $reflection->getMethod('buildPropertiesObject');
     $method->setAccessible(true);
 
     $properties = $method->invoke($this->service, $map, $data);
 
-    expect($properties)->toBeInstanceOf(\HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate::class);
+    expect($properties)->toBeInstanceOf(SimplePublicObjectInputForCreate::class);
     expect($properties->getProperties()['email'])->toBe('test@example.com');
     expect($properties->getProperties()['firstname'])->toBe('John');
     expect($properties->getProperties()['lastname'])->toBe('Doe');
@@ -54,13 +55,13 @@ test('it handles dynamic properties in data array', function () {
     ];
 
     // Use reflection to test protected method
-    $reflection = new \ReflectionClass($this->service);
+    $reflection = new ReflectionClass($this->service);
     $method = $reflection->getMethod('buildPropertiesObject');
     $method->setAccessible(true);
 
     $properties = $method->invoke($this->service, $map, $data);
 
-    expect($properties)->toBeInstanceOf(\HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate::class);
+    expect($properties)->toBeInstanceOf(SimplePublicObjectInputForCreate::class);
 
     // Check mapped properties
     expect($properties->getProperties()['email'])->toBe('test@example.com');
@@ -169,7 +170,7 @@ test('it skips execution when hubspot is disabled', function () {
     ];
 
     expect(fn () => $this->service->createContact($data, 'TestModel'))
-        ->toThrow(\Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
+        ->toThrow(Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
 });
 
 test('it skips execution when no api key is configured', function () {
@@ -188,5 +189,5 @@ test('it skips execution when no api key is configured', function () {
     ];
 
     expect(fn () => $this->service->createContact($data, 'TestModel'))
-        ->toThrow(\Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
+        ->toThrow(Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
 });

--- a/tests/Unit/Jobs/SyncHubspotCompanyJobTest.php
+++ b/tests/Unit/Jobs/SyncHubspotCompanyJobTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use Tapp\LaravelHubspot\Jobs\SyncHubspotCompanyJob;
 
 test('it extends queue job', function () {
     $job = new SyncHubspotCompanyJob([], 'create', 'TestModel');
 
-    expect($job)->toBeInstanceOf(\Illuminate\Contracts\Queue\ShouldQueue::class);
+    expect($job)->toBeInstanceOf(ShouldQueue::class);
 });
 
 test('it has correct properties', function () {
@@ -55,7 +56,7 @@ test('it logs permanent failure', function () {
     $modelData = ['id' => 1, 'name' => 'Test Company'];
     $job = new SyncHubspotCompanyJob($modelData, 'create', 'TestModel');
 
-    $exception = new \Exception('Test failure');
+    $exception = new Exception('Test failure');
     $job->failed($exception);
 
     expect(true)->toBeTrue();

--- a/tests/Unit/Jobs/SyncHubspotContactJobTest.php
+++ b/tests/Unit/Jobs/SyncHubspotContactJobTest.php
@@ -79,7 +79,7 @@ test('it logs error when service fails', function () {
 
     $job = new SyncHubspotContactJob($modelData, 'create', 'TestModel');
 
-    expect(fn () => $job->handle())->toThrow(\Exception::class);
+    expect(fn () => $job->handle())->toThrow(Exception::class);
 });
 
 test('it logs permanent failure', function () {
@@ -99,7 +99,7 @@ test('it logs permanent failure', function () {
 
     $job = new SyncHubspotContactJob($modelData, 'create', 'TestModel');
 
-    expect(fn () => $job->failed(new \Exception('Test failure')))->not->toThrow();
+    expect(fn () => $job->failed(new Exception('Test failure')))->not->toThrow();
 });
 
 test('it handles delete operation', function () {
@@ -125,5 +125,5 @@ test('it skips execution when no api key is configured', function () {
     $modelData = ['id' => 1, 'email' => 'test@example.com'];
     $job = new SyncHubspotContactJob($modelData, 'create', 'TestModel');
 
-    expect(fn () => $job->handle())->toThrow(\Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
+    expect(fn () => $job->handle())->toThrow(Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
 });

--- a/tests/Unit/Models/HubspotContactTraitTest.php
+++ b/tests/Unit/Models/HubspotContactTraitTest.php
@@ -111,7 +111,7 @@ test('updateOrCreateHubspotContact falls back to createContact when updateContac
     $mockService->shouldReceive('updateContact')
         ->once()
         ->with(Mockery::type('array'))
-        ->andThrow(new \Exception('Update failed'));
+        ->andThrow(new Exception('Update failed'));
 
     $mockService->shouldReceive('createContact')
         ->once()

--- a/tests/Unit/Observers/HubspotCompanyObserverTest.php
+++ b/tests/Unit/Observers/HubspotCompanyObserverTest.php
@@ -1,16 +1,18 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Queue;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Jobs\SyncHubspotCompanyJob;
+use Tapp\LaravelHubspot\Models\HubspotCompany;
 use Tapp\LaravelHubspot\Observers\HubspotCompanyObserver;
 use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
 
 // Test model for observer tests
-class CompanyObserverTestModel extends \Illuminate\Database\Eloquent\Model implements HubspotModelInterface
+class CompanyObserverTestModel extends Model implements HubspotModelInterface
 {
+    use HubspotCompany;
     use HubspotModelTrait;
-    use \Tapp\LaravelHubspot\Models\HubspotCompany;
 
     protected $fillable = ['name', 'domain', 'hubspot_id'];
 

--- a/tests/Unit/Observers/HubspotContactObserverTest.php
+++ b/tests/Unit/Observers/HubspotContactObserverTest.php
@@ -135,7 +135,7 @@ test('it includes dynamic properties from overridden hubspot properties method',
     $testModel->last_name = 'Doe';
 
     // Use reflection to test the protected method
-    $reflection = new \ReflectionClass($this->observer);
+    $reflection = new ReflectionClass($this->observer);
     $method = $reflection->getMethod('prepareJobData');
     $method->setAccessible(true);
 

--- a/tests/Unit/Services/PropertyConverterTest.php
+++ b/tests/Unit/Services/PropertyConverterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Carbon\Carbon;
+use Tapp\LaravelHubspot\Services\PropertyConverter;
+
+enum TestStringBackedEnum: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+
+enum TestIntBackedEnum: int
+{
+    case Low = 1;
+    case High = 10;
+}
+
+enum TestUnitEnum
+{
+    case Pending;
+    case Complete;
+}
+
+test('converts string-backed enum to its value', function () {
+    $result = PropertyConverter::convertValueForHubspot(TestStringBackedEnum::Active, 'status');
+
+    expect($result)->toBe('active');
+});
+
+test('converts int-backed enum to string of its value', function () {
+    $result = PropertyConverter::convertValueForHubspot(TestIntBackedEnum::High, 'priority');
+
+    expect($result)->toBe('10');
+});
+
+test('converts unit enum to its name', function () {
+    $result = PropertyConverter::convertValueForHubspot(TestUnitEnum::Pending, 'state');
+
+    expect($result)->toBe('Pending');
+});
+
+test('converts null to null', function () {
+    $result = PropertyConverter::convertValueForHubspot(null, 'field');
+
+    expect($result)->toBeNull();
+});
+
+test('converts Carbon instance to ISO string', function () {
+    $date = Carbon::create(2026, 3, 13, 12, 0, 0, 'UTC');
+    $result = PropertyConverter::convertValueForHubspot($date, 'date');
+
+    expect($result)->toBe($date->toISOString());
+});
+
+test('converts boolean true to string true', function () {
+    $result = PropertyConverter::convertValueForHubspot(true, 'flag');
+
+    expect($result)->toBe('true');
+});
+
+test('converts boolean false to string false', function () {
+    $result = PropertyConverter::convertValueForHubspot(false, 'flag');
+
+    expect($result)->toBe('false');
+});
+
+test('converts numeric value to string', function () {
+    $result = PropertyConverter::convertValueForHubspot(42, 'count');
+
+    expect($result)->toBe('42');
+});
+
+test('converts indexed array to comma-separated string', function () {
+    $result = PropertyConverter::convertValueForHubspot(['a', 'b', 'c'], 'tags');
+
+    expect($result)->toBe('a, b, c');
+});
+
+test('converts empty array to null', function () {
+    $result = PropertyConverter::convertValueForHubspot([], 'tags');
+
+    expect($result)->toBeNull();
+});
+
+test('converts associative array with en key to its value', function () {
+    $result = PropertyConverter::convertValueForHubspot(['en' => 'Hello', 'fr' => 'Bonjour'], 'greeting');
+
+    expect($result)->toBe('Hello');
+});
+
+test('throws for object without toString or toArray', function () {
+    $obj = new stdClass;
+
+    PropertyConverter::convertValueForHubspot($obj, 'bad_field');
+})->throws(\InvalidArgumentException::class);
+
+test('converts plain string as-is', function () {
+    $result = PropertyConverter::convertValueForHubspot('hello', 'name');
+
+    expect($result)->toBe('hello');
+});

--- a/tests/Unit/Services/PropertyConverterTest.php
+++ b/tests/Unit/Services/PropertyConverterTest.php
@@ -92,7 +92,7 @@ test('throws for object without toString or toArray', function () {
     $obj = new stdClass;
 
     PropertyConverter::convertValueForHubspot($obj, 'bad_field');
-})->throws(\InvalidArgumentException::class);
+})->throws(InvalidArgumentException::class);
 
 test('converts plain string as-is', function () {
     $result = PropertyConverter::convertValueForHubspot('hello', 'name');


### PR DESCRIPTION
## Summary

- Add `BackedEnum` and `UnitEnum` handling to `PropertyConverter::convertValueForHubspot()` before the generic `is_object()` branch
- `BackedEnum` instances return `(string) $value->value` (works for both string and int backed enums)
- `UnitEnum` instances return `$value->name` as a fallback
- Fixes `InvalidArgumentException` when Laravel models cast attributes to PHP enums (e.g. `EmploymentStatus`) and those attributes are mapped via `$hubspotMap`

## Test plan

- [x] Added `tests/Unit/Services/PropertyConverterTest.php` with 13 test cases covering: string-backed enum, int-backed enum, unit enum, null, Carbon, booleans, arrays (indexed/associative/empty), numeric, string, and error case for unconvertible objects
- [x] All 47 existing package unit tests still pass
- [x] Verified end-to-end in a consuming project (chw) that `employment_status` cast to `EmploymentStatus` enum serializes correctly through `hubspotPropertiesObject()`


Made with [Cursor](https://cursor.com)