### PR TITLE
CU-868k3r7g6-restore-bulk-single-sync-parity

### DIFF
--- a/src/Commands/SyncHubspotContacts.php
+++ b/src/Commands/SyncHubspotContacts.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
+use Tapp\LaravelHubspot\Support\HubspotModelDataPreparer;
 
 class SyncHubspotContacts extends Command
 {
@@ -125,48 +126,6 @@ class SyncHubspotContacts extends Command
      */
     protected function prepareContactData(Model $contact): array
     {
-        $data = $contact->toArray();
-
-        // Service expects hubspot_id and modelClass; use getHubspotId() so custom column (e.g. hubspot_contact_id) is respected
-        $data['hubspot_id'] = $contact instanceof HubspotModelInterface ? $contact->getHubspotId() : ($data['hubspot_id'] ?? null);
-        $data['id'] = $contact->getKey();
-        $data['modelClass'] = get_class($contact);
-
-        // Add HubSpot-specific properties
-        $data['hubspotMap'] = $contact->hubspotMap ?? [];
-        $data['hubspotUpdateMap'] = $contact->hubspotUpdateMap ?? [];
-        $data['hubspotCompanyRelation'] = $contact->hubspotCompanyRelation ?? '';
-
-        // Include dynamic properties from hubspotProperties and getHubspotProperties
-        $map = $contact->hubspotMap ?? [];
-        $dynamicProperties = [];
-        if (method_exists($contact, 'hubspotProperties')) {
-            $dynamicProperties = array_merge($dynamicProperties, $contact->hubspotProperties($map));
-        }
-        if (method_exists($contact, 'getHubspotProperties')) {
-            $dynamicProperties = array_merge($dynamicProperties, $contact->getHubspotProperties($map));
-        }
-        if (! empty($dynamicProperties)) {
-            $data['dynamicProperties'] = [];
-            foreach ($dynamicProperties as $hubspotField => $value) {
-                if (! in_array($hubspotField, array_values($map))) {
-                    $data['dynamicProperties'][$hubspotField] = $value;
-                }
-            }
-        }
-
-        // Include company relation data if it exists
-        if (! empty($contact->hubspotCompanyRelation)) {
-            $company = $contact->getRelationValue($contact->hubspotCompanyRelation);
-            if ($company) {
-                $data['hubspotCompanyRelation'] = [
-                    'id' => $company->getKey(),
-                    'hubspot_id' => $company->getAttribute('hubspot_id') ?? null,
-                    'name' => $company->name ?? $company->getAttribute('name'),
-                ];
-            }
-        }
-
-        return $data;
+        return HubspotModelDataPreparer::fromModel($contact);
     }
 }

--- a/src/Models/HubspotContact.php
+++ b/src/Models/HubspotContact.php
@@ -4,10 +4,10 @@ namespace Tapp\LaravelHubspot\Models;
 
 use HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate as ContactObject;
 use Illuminate\Support\Facades\Log;
-use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Observers\HubspotContactObserver;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
 use Tapp\LaravelHubspot\Services\PropertyConverter;
+use Tapp\LaravelHubspot\Support\HubspotModelDataPreparer;
 use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
 
 trait HubspotContact
@@ -109,37 +109,7 @@ trait HubspotContact
     {
         $service = app(HubspotContactService::class);
 
-        $data = [
-            'id' => $this->getKey(),
-            'hubspot_id' => $this->getHubspotId(),
-            'hubspotMap' => $this->getHubspotMap(),
-            'hubspotUpdateMap' => $this->getHubspotUpdateMap(),
-            'hubspotCompanyRelation' => $this->getHubspotCompanyRelation(),
-        ];
-
-        // Include mapped fields
-        foreach ($this->getHubspotMap() as $hubspotField => $modelField) {
-            $data[$modelField] = data_get($this, $modelField);
-        }
-
-        // Include dynamic properties
-        $dynamicProperties = $this->getHubspotProperties($this->getHubspotMap());
-        if (! empty($dynamicProperties)) {
-            $data['dynamicProperties'] = $dynamicProperties;
-        }
-
-        // Include company relation data if it exists
-        $companyRelation = $this->getHubspotCompanyRelation();
-        if (! empty($companyRelation)) {
-            $company = $this->getRelationValue($companyRelation);
-            if ($company) {
-                $data['hubspotCompanyRelation'] = [
-                    'id' => $company->getKey(),
-                    'hubspot_id' => $company instanceof HubspotModelInterface ? $company->getHubspotId() : ($company->hubspot_id ?? null),
-                    'name' => $company->name ?? $company->getAttribute('name'),
-                ];
-            }
-        }
+        $data = HubspotModelDataPreparer::fromModel($this);
 
         // Try to update first if hubspot_id exists, otherwise create
         if (! empty($this->getHubspotId())) {

--- a/src/Observers/HubspotContactObserver.php
+++ b/src/Observers/HubspotContactObserver.php
@@ -5,6 +5,7 @@ namespace Tapp\LaravelHubspot\Observers;
 use Illuminate\Database\Eloquent\Model;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Jobs\SyncHubspotContactJob;
+use Tapp\LaravelHubspot\Support\HubspotModelDataPreparer;
 
 class HubspotContactObserver
 {
@@ -100,57 +101,6 @@ class HubspotContactObserver
      */
     protected function prepareJobData(Model $model): array
     {
-        if (! $model instanceof HubspotModelInterface) {
-            return [];
-        }
-
-        $data = [
-            'id' => $model->getKey(),
-            'hubspot_id' => $model->getHubspotId(),
-            'hubspotMap' => $model->getHubspotMap(),
-            'hubspotUpdateMap' => $model->getHubspotUpdateMap(),
-            'hubspotCompanyRelation' => $model->getHubspotCompanyRelation(),
-        ];
-
-        // Include HubSpot-mapped fields
-        foreach ($model->getHubspotMap() as $hubspotField => $modelField) {
-            $data[$modelField] = $this->getNestedValue($model, $modelField);
-        }
-
-        // Include dynamic properties from overridden hubspotProperties method
-        $dynamicProperties = $model->getHubspotProperties($model->getHubspotMap());
-        if (! empty($dynamicProperties)) {
-            $data['dynamicProperties'] = [];
-
-            foreach ($dynamicProperties as $hubspotField => $value) {
-                // Only add if not already included as a mapped field
-                if (! in_array($hubspotField, array_values($model->getHubspotMap()))) {
-                    $data['dynamicProperties'][$hubspotField] = $value;
-                }
-            }
-        }
-
-        // Include company relation data if it exists
-        $companyRelation = $model->getHubspotCompanyRelation();
-        if (! empty($companyRelation)) {
-            $company = $model->getRelationValue($companyRelation);
-            if ($company) {
-                $data['hubspotCompanyRelation'] = [
-                    'id' => $company->getKey(),
-                    'hubspot_id' => $company instanceof HubspotModelInterface ? $company->getHubspotId() : ($company->hubspot_id ?? null),
-                    'name' => $company->name ?? $company->getAttribute('name'),
-                ];
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * Get nested value from model using dot notation.
-     */
-    protected function getNestedValue(Model $model, string $key)
-    {
-        return data_get($model, $key);
+        return HubspotModelDataPreparer::fromModel($model);
     }
 }

--- a/src/Support/HubspotModelDataPreparer.php
+++ b/src/Support/HubspotModelDataPreparer.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tapp\LaravelHubspot\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+
+class HubspotModelDataPreparer
+{
+    /**
+     * Build a flat data array for HubSpot contact sync from a model.
+     *
+     * @return array<string, mixed>
+     */
+    public static function fromModel(Model $model): array
+    {
+        if (! $model instanceof HubspotModelInterface) {
+            return [];
+        }
+
+        $map = $model->getHubspotMap();
+
+        $data = [
+            'id' => $model->getKey(),
+            'hubspot_id' => $model->getHubspotId(),
+            'hubspotMap' => $map,
+            'hubspotUpdateMap' => $model->getHubspotUpdateMap(),
+            'hubspotCompanyRelation' => $model->getHubspotCompanyRelation(),
+        ];
+
+        foreach ($map as $hubspotField => $modelField) {
+            $data[$modelField] = data_get($model, $modelField);
+        }
+
+        $dynamicProperties = $model->getHubspotProperties($map);
+
+        if (method_exists($model, 'hubspotProperties')) {
+            $dynamicProperties = array_merge(
+                $dynamicProperties,
+                $model->hubspotProperties($map)
+            );
+        }
+
+        if ($dynamicProperties !== []) {
+            $data['dynamicProperties'] = [];
+
+            foreach ($dynamicProperties as $hubspotField => $value) {
+                if (! array_key_exists($hubspotField, $map)) {
+                    $data['dynamicProperties'][$hubspotField] = $value;
+
+                    continue;
+                }
+
+                $modelField = $map[$hubspotField];
+
+                if (data_get($data, $modelField) === null && $value !== null) {
+                    $data['dynamicProperties'][$hubspotField] = $value;
+                }
+            }
+        }
+
+        $companyRelation = $model->getHubspotCompanyRelation();
+
+        if (! empty($companyRelation)) {
+            $company = $model->getRelationValue($companyRelation);
+
+            if ($company) {
+                $data['hubspotCompanyRelation'] = [
+                    'id' => $company->getKey(),
+                    'hubspot_id' => $company instanceof HubspotModelInterface
+                        ? $company->getHubspotId()
+                        : ($company->hubspot_id ?? null),
+                    'name' => $company->name ?? $company->getAttribute('name'),
+                ];
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/Models/HubspotContactTraitTest.php
+++ b/tests/Unit/Models/HubspotContactTraitTest.php
@@ -1,13 +1,20 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Models\HubspotContact;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
+use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
 
 // Create a test model that uses the trait
-class TestUserModel implements HubspotModelInterface
+class TestUserModel extends Model implements HubspotModelInterface
 {
     use HubspotContact;
+    use HubspotModelTrait;
+
+    protected $guarded = [];
+
+    protected $table = 'test_user_models';
 
     public $id = 1;
 
@@ -58,11 +65,6 @@ class TestUserModel implements HubspotModelInterface
     public function setHubspotId(?string $hubspotId): void
     {
         $this->hubspot_id = $hubspotId;
-    }
-
-    public function getRelationValue(string $relation)
-    {
-        return null;
     }
 }
 

--- a/tests/Unit/Support/HubspotModelDataPreparerTest.php
+++ b/tests/Unit/Support/HubspotModelDataPreparerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Tapp\LaravelHubspot\Commands\SyncHubspotContacts;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Observers\HubspotContactObserver;
+use Tapp\LaravelHubspot\Services\HubspotContactService;
+use Tapp\LaravelHubspot\Support\HubspotModelDataPreparer;
+use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
+
+class HubspotParityTestModel extends Model implements HubspotModelInterface
+{
+    use HubspotModelTrait;
+
+    protected $guarded = [];
+
+    protected $table = 'hubspot_parity_test_models';
+
+    public array $hubspotMap = [
+        'email' => 'email',
+        'organization' => 'organization_name',
+        'user_type' => 'type.name',
+    ];
+
+    public function getHubspotProperties(array $map): array
+    {
+        return [
+            'course_progress' => '75%',
+        ];
+    }
+
+    public function hubspotProperties(array $map): array
+    {
+        return [
+            'certification_status' => 'Active',
+        ];
+    }
+
+    protected function organizationName(): Attribute
+    {
+        return Attribute::get(fn () => $this->organization?->name);
+    }
+}
+
+function makeParityTestModel(): HubspotParityTestModel
+{
+    $typeModel = new class extends Model
+    {
+        protected $guarded = [];
+    };
+    $typeModel->forceFill(['name' => 'Coordinator']);
+
+    $organizationModel = new class extends Model
+    {
+        protected $guarded = [];
+    };
+    $organizationModel->forceFill(['name' => 'Acme Health']);
+
+    $model = new HubspotParityTestModel;
+    $model->forceFill([
+        'id' => 42,
+        'email' => 'user@example.com',
+    ]);
+    $model->setRelation('organization', $organizationModel);
+    $model->setRelation('type', $typeModel);
+
+    return $model;
+}
+
+test('preparer resolves accessor and dot notation mapped fields', function () {
+    $model = makeParityTestModel();
+
+    $data = HubspotModelDataPreparer::fromModel($model);
+
+    expect($data['email'])->toBe('user@example.com');
+    expect($data['organization_name'])->toBe('Acme Health');
+    expect($data['type.name'])->toBe('Coordinator');
+    expect($data['dynamicProperties']['course_progress'])->toBe('75%');
+    expect($data['dynamicProperties']['certification_status'])->toBe('Active');
+    expect($data['dynamicProperties'])->not->toHaveKey('organization');
+    expect($data['dynamicProperties'])->not->toHaveKey('user_type');
+});
+
+test('bulk and observer produce identical sync payloads', function () {
+    $model = makeParityTestModel();
+
+    $command = new SyncHubspotContacts;
+    $commandReflection = new ReflectionClass($command);
+    $prepareContactData = $commandReflection->getMethod('prepareContactData');
+    $prepareContactData->setAccessible(true);
+
+    $observer = new HubspotContactObserver;
+    $observerReflection = new ReflectionClass($observer);
+    $prepareJobData = $observerReflection->getMethod('prepareJobData');
+    $prepareJobData->setAccessible(true);
+
+    $bulkData = $prepareContactData->invoke($command, $model);
+    $observerData = $prepareJobData->invoke($observer, $model);
+
+    expect($bulkData)->toBe($observerData);
+});
+
+test('preparer returns empty array for non hubspot models', function () {
+    $model = new class extends Model
+    {
+        protected $guarded = [];
+    };
+
+    expect(HubspotModelDataPreparer::fromModel($model))->toBe([]);
+});
+
+test('preparer output includes accessor fields in hubspot properties object', function () {
+    $model = makeParityTestModel();
+    $data = HubspotModelDataPreparer::fromModel($model);
+
+    $service = app(HubspotContactService::class);
+    $reflection = new ReflectionClass($service);
+    $method = $reflection->getMethod('buildPropertiesObject');
+    $method->setAccessible(true);
+
+    $properties = $method->invoke($service, $model->getHubspotMap(), $data);
+
+    expect($properties->getProperties()['organization'])->toBe('Acme Health');
+    expect($properties->getProperties()['email'])->toBe('user@example.com');
+    expect($properties->getProperties()['course_progress'])->toBe('75%');
+});


### PR DESCRIPTION
## Summary
- Extract `HubspotModelDataPreparer` to build a unified sync payload from Eloquent models using `data_get` per mapped field
- Refactor bulk sync (`hubspot:sync-contacts`), observer jobs, and `updateOrCreateHubspotContact()` to use the shared preparer
- Fix bulk sync missing accessor-backed attributes (e.g. `organization_name`) that single sync already resolved correctly

## Test plan
- [x] `./vendor/bin/pest` — 56 passed
- [x] `./vendor/bin/pint`
- [x] `./vendor/bin/phpstan analyse`
- [ ] After release, verify CHECK `php artisan hubspot:sync-contacts` populates organization/program fields


Made with [Cursor](https://cursor.com)