### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     "require": {
         "php": "^8.2",
         "hubspot/api-client": "^14.1",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^3.6||^2.10",
-        "orchestra/testbench": "^10.0||^9.0||^8.22.0",
-        "pestphp/pest": "^3.0||^2.34",
-        "pestphp/pest-plugin-arch": "^3.0||^2.7",
-        "pestphp/pest-plugin-laravel": "^3.0||^2.3",
+        "orchestra/testbench": "^11.0||^10.0||^9.0||^8.22.0",
+        "pestphp/pest": "^5.0||^4.0||^3.0||^2.34",
+        "pestphp/pest-plugin-arch": "^5.0||^4.0||^3.0||^2.7",
+        "pestphp/pest-plugin-laravel": "^5.0||^4.0||^3.0||^2.3",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^2.0||^1.1",
         "phpstan/phpstan-phpunit": "^2.0||^1.3",
@@ -64,8 +64,8 @@
         "test-unit": "vendor/bin/pest --group=unit",
         "test-integration": "vendor/bin/pest --group=integration",
         "test-feature": "vendor/bin/pest --group=feature",
-        "test-coverage": "vendor/bin/pest --coverage",
-        "test-coverage-unit": "vendor/bin/pest --group=unit --coverage",
+        "test-coverage": "vendor/bin/pest --coverage --coverage-html=build/coverage --coverage-text=build/coverage.txt --coverage-clover=build/logs/clover.xml",
+        "test-coverage-unit": "vendor/bin/pest --group=unit --coverage --coverage-html=build/coverage --coverage-text=build/coverage.txt --coverage-clover=build/logs/clover.xml",
         "format": "vendor/bin/pint"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>


### PR DESCRIPTION
## Summary
- Widen version constraints (`illuminate/contracts`, `orchestra/testbench`, `pestphp/pest`, `pest-plugin-arch`, `pest-plugin-laravel`) to allow Laravel 13, testbench 11, and Pest 4/5
- Add a Laravel 13 job (paired with testbench 11) to the CI test matrix
- Fix `phpunit.xml.dist`'s coverage config: the `<coverage><report>...</report></coverage>` wrapper is PHPUnit 10/11 syntax that PHPUnit 12/13 (required by Pest 4/5) rejects during schema validation. With `failOnWarning="true"` set, this caused the suite to silently report zero tests and exit non-zero under the newer stack. The report config was moved to explicit `--coverage-html`/`--coverage-text`/`--coverage-clover` CLI flags on the `test-coverage` composer scripts, which work identically across all PHPUnit versions.

## Test plan
- [x] Verified in isolated copies that the full suite passes on Laravel 11 (Pest 4/testbench 9), Laravel 12 (Pest 3/testbench 10, existing pinned combo), and Laravel 13 (Pest 4/testbench 11 and Pest 5/testbench 11, PHPUnit 12/13)
- [x] `vendor/bin/phpstan analyse` passes with no errors
- [ ] CI run on this PR across the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)