### PR TITLE
Search mapped emails before creating HubSpot contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to `Laravel-Hubspot` will be documented in this file.
 
 ### What's Changed
 
-* Search all mapped email values (`email` and `secondary_email`) before creating a contact, so an existing contact under a non-primary mapped email is updated instead of duplicated
+* Search configured mapped email values before creating a contact, so an existing contact under a non-primary mapped email is updated instead of duplicated
+* Add `contact_email_properties` config (defaults: `email`, `secondary_email`) so apps can include custom HubSpot email properties such as `work_email` or `personal_email`
 
 ## v2.2.0 - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to `Laravel-Hubspot` will be documented in this file.
 
 ## Unreleased
 
+## v2.3.0 - 2026-08-21
+
 ### What's Changed
 
 * Search configured mapped email values before creating a contact, so an existing contact under a non-primary mapped email is updated instead of duplicated
 * Add `contact_email_properties` config (defaults: `email`, `secondary_email`) so apps can include custom HubSpot email properties such as `work_email` or `personal_email`
+
+**Full Changelog**: https://github.com/TappNetwork/Laravel-HubSpot/compare/v2.2.0...v2.3.0
 
 ## v2.2.0 - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `Laravel-Hubspot` will be documented in this file.
 
+## Unreleased
+
+### What's Changed
+
+* Search all mapped email values (`email` and `secondary_email`) before creating a contact, so an existing contact under a non-primary mapped email is updated instead of duplicated
+
 ## v2.2.0 - 2026-08-02
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ HUBSPOT_PROPERTY_GROUP=app_user_profile
 HUBSPOT_PROPERTY_GROUP_LABEL=App User Profile
 ```
 
+Publish the config to customize options:
+
+```bash
+php artisan vendor:publish --tag="laravel-hubspot-config"
+```
+
+### Contact email properties (dedupe)
+
+Before creating a contact, the package searches HubSpot using values from configured `$hubspotMap` keys. Defaults are HubSpot property names `email` and `secondary_email` (the latter is commonly a custom portal property). Add any other email properties your portal uses:
+
+```php
+// config/hubspot.php
+'contact_email_properties' => [
+    'email',
+    'secondary_email',
+    'work_email',
+    'personal_email',
+],
+```
+
+Only properties listed here are used for pre-create lookup. They must also appear as keys in your model's `$hubspotMap`.
+
 ## Usage
 
 ### User Model Setup

--- a/config/hubspot.php
+++ b/config/hubspot.php
@@ -12,6 +12,14 @@ return [
     'contact_id_column' => env('HUBSPOT_CONTACT_ID_COLUMN', 'hubspot_id'),
     'company_id_column' => env('HUBSPOT_COMPANY_ID_COLUMN', 'hubspot_id'),
 
+    // HubSpot contact property names from hubspotMap whose values are used for
+    // pre-create contact lookup (dedupe). Include any custom email properties
+    // your portal maps (e.g. work_email, personal_email).
+    'contact_email_properties' => [
+        'email',
+        'secondary_email',
+    ],
+
     // Queue configuration
     'queue' => [
         'enabled' => env('HUBSPOT_QUEUE_ENABLED', true),

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -25,7 +25,7 @@ class HubspotContactService
     public function createContact(array $data, string $modelClass): array
     {
         $existingContact = $this->findContactByMappedEmails($data);
-        if ($existingContact && isset($existingContact['id'])) {
+        if ($existingContact !== null) {
             Log::info('HubSpot contact already exists for mapped email, updating instead of creating', [
                 'hubspot_id' => $existingContact['id'],
                 'emails' => $this->getMappedEmailValues($data),

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -264,7 +264,7 @@ class HubspotContactService
     }
 
     /**
-     * Find a contact by any email value mapped on the model (identity email and secondary_email).
+     * Find a contact by any configured email property value mapped on the model.
      *
      * @param  array<string, mixed>  $data
      * @return array{id: string, properties: array<string, mixed>}|null
@@ -282,7 +282,23 @@ class HubspotContactService
     }
 
     /**
-     * Collect unique email values from hubspotMap keys named email or secondary_email.
+     * HubSpot contact property names used when collecting emails for pre-create lookup.
+     *
+     * @return list<string>
+     */
+    protected function contactEmailProperties(): array
+    {
+        $properties = config('hubspot.contact_email_properties', ['email', 'secondary_email']);
+
+        if (! is_array($properties)) {
+            return ['email', 'secondary_email'];
+        }
+
+        return array_values(array_filter($properties, fn (mixed $property): bool => is_string($property) && $property !== ''));
+    }
+
+    /**
+     * Collect unique email values from hubspotMap keys listed in contact_email_properties.
      *
      * @param  array<string, mixed>  $data
      * @return list<string>
@@ -291,8 +307,9 @@ class HubspotContactService
     {
         $emails = [];
         $map = $data['hubspotMap'] ?? [];
+        $emailProperties = $this->contactEmailProperties();
 
-        foreach (['email', 'secondary_email'] as $hubspotProperty) {
+        foreach ($emailProperties as $hubspotProperty) {
             if (! isset($map[$hubspotProperty])) {
                 continue;
             }
@@ -312,7 +329,7 @@ class HubspotContactService
         }
 
         if (isset($data['dynamicProperties']) && is_array($data['dynamicProperties'])) {
-            foreach (['email', 'secondary_email'] as $hubspotProperty) {
+            foreach ($emailProperties as $hubspotProperty) {
                 $value = $data['dynamicProperties'][$hubspotProperty] ?? null;
                 if (is_string($value) && $value !== '') {
                     $emails[strtolower(trim($value))] = trim($value);

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -17,9 +17,30 @@ class HubspotContactService
 {
     /**
      * Create a new HubSpot contact.
+     *
+     * Searches for an existing contact by all mapped email values before creating,
+     * so a contact that already exists under a secondary mapped email is updated
+     * instead of duplicated.
      */
     public function createContact(array $data, string $modelClass): array
     {
+        $existingContact = $this->findContactByMappedEmails($data);
+        if ($existingContact && isset($existingContact['id'])) {
+            Log::info('HubSpot contact already exists for mapped email, updating instead of creating', [
+                'hubspot_id' => $existingContact['id'],
+                'emails' => $this->getMappedEmailValues($data),
+            ]);
+
+            $this->updateModelHubspotId($data['id'] ?? null, (string) $existingContact['id'], $modelClass);
+
+            $data['hubspot_id'] = $existingContact['id'];
+            $data['modelClass'] = $modelClass;
+            $this->updateContact($data);
+            $this->associateCompanyIfNeeded((string) $existingContact['id'], $data);
+
+            return $existingContact;
+        }
+
         $properties = $this->buildPropertiesObject($data['hubspotMap'] ?? [], $data);
 
         try {
@@ -239,16 +260,67 @@ class HubspotContactService
             }
         }
 
-        // Find contact by email using the Search API (getById does not accept email)
-        $emailField = $this->getMappedEmailField($data);
-        if ($emailField) {
-            $contact = $this->findContactByEmail($emailField, $data);
+        return $this->findContactByMappedEmails($data);
+    }
+
+    /**
+     * Find a contact by any email value mapped on the model (identity email and secondary_email).
+     *
+     * @param  array<string, mixed>  $data
+     * @return array{id: string, properties: array<string, mixed>}|null
+     */
+    protected function findContactByMappedEmails(array $data): ?array
+    {
+        foreach ($this->getMappedEmailValues($data) as $email) {
+            $contact = $this->findContactByEmail($email, $data);
             if ($contact !== null) {
                 return $contact;
             }
         }
 
         return null;
+    }
+
+    /**
+     * Collect unique email values from hubspotMap keys named email or secondary_email.
+     *
+     * @param  array<string, mixed>  $data
+     * @return list<string>
+     */
+    protected function getMappedEmailValues(array $data): array
+    {
+        $emails = [];
+        $map = $data['hubspotMap'] ?? [];
+
+        foreach (['email', 'secondary_email'] as $hubspotProperty) {
+            if (! isset($map[$hubspotProperty])) {
+                continue;
+            }
+
+            $modelField = $map[$hubspotProperty];
+            $value = str_contains((string) $modelField, '.')
+                ? data_get($data, $modelField)
+                : ($data[$modelField] ?? null);
+
+            if (is_string($value) && $value !== '') {
+                $emails[strtolower(trim($value))] = trim($value);
+            }
+        }
+
+        if ($emails === [] && ! empty($data['email']) && is_string($data['email'])) {
+            $emails[strtolower(trim($data['email']))] = trim($data['email']);
+        }
+
+        if (isset($data['dynamicProperties']) && is_array($data['dynamicProperties'])) {
+            foreach (['email', 'secondary_email'] as $hubspotProperty) {
+                $value = $data['dynamicProperties'][$hubspotProperty] ?? null;
+                if (is_string($value) && $value !== '') {
+                    $emails[strtolower(trim($value))] = trim($value);
+                }
+            }
+        }
+
+        return array_values($emails);
     }
 
     /**

--- a/tests/Unit/HubspotContactServiceTest.php
+++ b/tests/Unit/HubspotContactServiceTest.php
@@ -176,7 +176,7 @@ test('it updates existing contact instead of creating when secondary mapped emai
     expect($result['id'])->toBe('99999');
 });
 
-test('it collects mapped email values from email and secondary_email map keys', function () {
+test('it collects mapped email values from configured contact_email_properties', function () {
     $data = [
         'email' => 'login@example.com',
         'secondary_email' => 'work@example.com',
@@ -195,6 +195,64 @@ test('it collects mapped email values from email and secondary_email map keys', 
     expect($emails)->toContain('work@example.com')
         ->and($emails)->toContain('login@example.com')
         ->and($emails)->toHaveCount(2);
+});
+
+test('it collects custom email properties when configured', function () {
+    config([
+        'hubspot.contact_email_properties' => [
+            'email',
+            'work_email',
+            'personal_email',
+        ],
+    ]);
+
+    $data = [
+        'login_email' => 'login@example.com',
+        'work' => 'work@example.com',
+        'personal' => 'personal@example.com',
+        'hubspotMap' => [
+            'email' => 'login_email',
+            'work_email' => 'work',
+            'personal_email' => 'personal',
+            'secondary_email' => 'login_email',
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->service);
+    $method = $reflection->getMethod('getMappedEmailValues');
+    $method->setAccessible(true);
+
+    $emails = $method->invoke($this->service, $data);
+
+    expect($emails)->toContain('login@example.com')
+        ->and($emails)->toContain('work@example.com')
+        ->and($emails)->toContain('personal@example.com')
+        ->and($emails)->toHaveCount(3);
+});
+
+test('it ignores unconfigured email map keys when collecting emails', function () {
+    config([
+        'hubspot.contact_email_properties' => [
+            'email',
+        ],
+    ]);
+
+    $data = [
+        'email' => 'login@example.com',
+        'secondary_email' => 'work@example.com',
+        'hubspotMap' => [
+            'email' => 'email',
+            'secondary_email' => 'secondary_email',
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->service);
+    $method = $reflection->getMethod('getMappedEmailValues');
+    $method->setAccessible(true);
+
+    $emails = $method->invoke($this->service, $data);
+
+    expect($emails)->toBe(['login@example.com']);
 });
 
 test('it updates contact successfully', function () {

--- a/tests/Unit/HubspotContactServiceTest.php
+++ b/tests/Unit/HubspotContactServiceTest.php
@@ -87,7 +87,14 @@ test('it creates contact successfully', function () {
         'lastname' => 'Doe',
     ]);
 
+    $mockSearchResponse = Mockery::mock();
+    $mockSearchResponse->shouldReceive('getTotal')->andReturn(0);
+
     // Mock the HubSpot facade
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
+        ->once()
+        ->andReturn($mockSearchResponse);
+
     Hubspot::shouldReceive('crm->contacts->basicApi->create')
         ->once()
         ->andReturn($mockResponse);
@@ -109,6 +116,85 @@ test('it creates contact successfully', function () {
     expect($result)->toBeArray();
     expect($result['id'])->toBe('12345');
     expect($result['properties']['email'])->toBe('test@example.com');
+});
+
+test('it updates existing contact instead of creating when secondary mapped email already exists', function () {
+    config(['hubspot.api_key' => 'dummy-key']);
+
+    $existingContact = new SimplePublicObject;
+    $existingContact->setId('99999');
+    $existingContact->setProperties([
+        'email' => 'login@example.com',
+        'firstname' => 'Jane',
+        'lastname' => 'Doe',
+    ]);
+
+    $mockSearchResponse = Mockery::mock();
+    $mockSearchResponse->shouldReceive('getTotal')->andReturn(1);
+    $mockSearchResponse->shouldReceive('getResults')->andReturn([$existingContact]);
+
+    $mockUpdateResponse = new SimplePublicObject;
+    $mockUpdateResponse->setId('99999');
+    $mockUpdateResponse->setProperties([
+        'email' => 'work@example.com',
+        'firstname' => 'Jane',
+        'lastname' => 'Doe',
+    ]);
+
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
+        ->once()
+        ->andReturn($mockSearchResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->getById')
+        ->with('99999')
+        ->andReturn(['id' => '99999']);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->update')
+        ->once()
+        ->with('99999', Mockery::any())
+        ->andReturn($mockUpdateResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
+
+    $data = [
+        'id' => 1,
+        'email' => 'login@example.com',
+        'secondary_email' => 'work@example.com',
+        'first_name' => 'Jane',
+        'last_name' => 'Doe',
+        'hubspotMap' => [
+            'email' => 'secondary_email',
+            'secondary_email' => 'email',
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ];
+
+    $result = $this->service->createContact($data, 'TestModel');
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('99999');
+});
+
+test('it collects mapped email values from email and secondary_email map keys', function () {
+    $data = [
+        'email' => 'login@example.com',
+        'secondary_email' => 'work@example.com',
+        'hubspotMap' => [
+            'email' => 'secondary_email',
+            'secondary_email' => 'email',
+        ],
+    ];
+
+    $reflection = new ReflectionClass($this->service);
+    $method = $reflection->getMethod('getMappedEmailValues');
+    $method->setAccessible(true);
+
+    $emails = $method->invoke($this->service, $data);
+
+    expect($emails)->toContain('work@example.com')
+        ->and($emails)->toContain('login@example.com')
+        ->and($emails)->toHaveCount(2);
 });
 
 test('it updates contact successfully', function () {


### PR DESCRIPTION
## Summary
- Before creating a contact, search HubSpot for all mapped email values (`email` and `secondary_email`), not only after a 409 on the primary mapped email.
- When a contact already exists under a secondary mapped email, attach `hubspot_id` and update instead of creating a duplicate.
- Keeps existing 409 handling as a fallback.

## Why
Apps that map HubSpot identity email to one model field and `secondary_email` to another (e.g. CHECK work vs login) were creating two contacts when the form contact lived on the non-primary mapped email.

## Test plan
- [x] Package unit test: create is skipped when a mapped secondary email already exists
- [x] Package unit test: mapped email value collection from `email` / `secondary_email` keys
- [ ] After merge, tag/release so CHECK can depend on a Packagist version


Made with [Cursor](https://cursor.com)