### PR TITLE
Find or create HubSpot contacts when update has no ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to `Laravel-Hubspot` will be documented in this file.
 
 ## Unreleased
 
+## v2.4.0 - 2026-08-24
+
+### What's Changed
+
 * When an update is queued without a HubSpot ID, reload the id from the local model or find/create the contact instead of throwing
 * Observer updates with no HubSpot ID dispatch a create job
 * Models can set `$hubspotSyncIgnoredFields` so mapped attributes (e.g. `last_login`) stay in `$hubspotMap` but do not trigger a sync by themselves
 * Queued contact jobs rebuild their payload from the live model before create/update
 * Writing `hubspot_id` back to the local model uses `saveQuietly()` so the observer does not queue another job
+
+**Full Changelog**: https://github.com/TappNetwork/Laravel-HubSpot/compare/v2.3.0...v2.4.0
 
 ## v2.3.0 - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `Laravel-Hubspot` will be documented in this file.
 
 ## Unreleased
 
+* When an update is queued without a HubSpot ID, reload the id from the local model or find/create the contact instead of throwing
+* Observer updates with no HubSpot ID dispatch a create job
+* Models can set `$hubspotSyncIgnoredFields` so mapped attributes (e.g. `last_login`) stay in `$hubspotMap` but do not trigger a sync by themselves
+* Queued contact jobs rebuild their payload from the live model before create/update
+* Writing `hubspot_id` back to the local model uses `saveQuietly()` so the observer does not queue another job
+
 ## v2.3.0 - 2026-08-21
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ class User extends Authenticatable implements HubspotModelInterface
         'first_name' => 'first_name',
         'last_name' => 'last_name',
         'user_type' => 'type.name', // Supports dot notation for relations
+        'app_last_login' => 'last_login',
+    ];
+
+    // Stay in `$hubspotMap` so they still sync with other changes / bulk sync,
+    // but do not queue a job when they are the only dirty attributes.
+    public array $hubspotSyncIgnoredFields = [
+        'last_login',
     ];
 }
 ```
@@ -85,6 +92,10 @@ class User extends Authenticatable implements HubspotModelInterface
 - `getHubspotId()` / `setHubspotId()` - Manages the HubSpot ID
 
 The traits (`HubspotContact`, `HubspotCompany`) provide the implementation for these methods, so you only need to implement the interface and define your `$hubspotMap` array.
+
+Optional: `$hubspotSyncIgnoredFields` (via `getHubspotSyncIgnoredFields()`) lists model attributes that remain in `$hubspotMap` but do not trigger an observer job on their own. Use this for high-churn fields such as `last_login`.
+
+If an update job runs before `hubspot_id` is written (register, then an immediate mapped-field save), the service reloads the id from the model or finds/creates the contact instead of throwing. Queued jobs also rebuild their payload from the live model before calling HubSpot, and writing `hubspot_id` uses `saveQuietly()` so that write does not queue another sync.
 
 ### Company Model Setup
 

--- a/src/Jobs/BaseHubspotJob.php
+++ b/src/Jobs/BaseHubspotJob.php
@@ -9,6 +9,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Support\HubspotModelDataPreparer;
 
 abstract class BaseHubspotJob implements ShouldQueue
 {
@@ -38,6 +40,10 @@ abstract class BaseHubspotJob implements ShouldQueue
     public function handle(): void
     {
         if (config('hubspot.disabled')) {
+            return;
+        }
+
+        if ($this->refreshLiveModelData() === false) {
             return;
         }
 
@@ -119,8 +125,46 @@ abstract class BaseHubspotJob implements ShouldQueue
         $model = $this->modelClass::find($this->modelData['id'] ?? null);
         if ($model instanceof Model && method_exists($model, 'setHubspotId')) {
             $model->setHubspotId($hubspotId);
-            $model->save();
+            $model->saveQuietly();
         }
+    }
+
+    /**
+     * Replace the dispatch-time snapshot with the current model row.
+     *
+     * @return bool false when the local record no longer exists
+     */
+    protected function refreshLiveModelData(): bool
+    {
+        if (! is_string($this->modelClass) || $this->modelClass === '' || ! class_exists($this->modelClass)) {
+            return true;
+        }
+
+        $modelId = $this->modelData['id'] ?? null;
+
+        if ($modelId === null || $modelId === '') {
+            return true;
+        }
+
+        /** @var Model|null $model */
+        $model = $this->modelClass::query()->find($modelId);
+
+        if (! $model instanceof Model) {
+            Log::info($this->getJobType().' sync skipped because the local model no longer exists', [
+                'model_class' => $this->modelClass,
+                'model_id' => $modelId,
+            ]);
+
+            return false;
+        }
+
+        $this->modelData = HubspotModelDataPreparer::fromModel($model);
+
+        if ($model instanceof HubspotModelInterface) {
+            $this->operation = ! empty($model->getHubspotId()) ? 'update' : 'create';
+        }
+
+        return true;
     }
 
     /**

--- a/src/Jobs/SyncHubspotCompanyJob.php
+++ b/src/Jobs/SyncHubspotCompanyJob.php
@@ -71,10 +71,14 @@ class SyncHubspotCompanyJob extends BaseHubspotJob
     protected function updateCompany(): void
     {
         if (empty($this->modelData['hubspot_id'])) {
-            throw new \Exception(
-                'HubSpot ID missing in model. Cannot update company: '.($this->modelData['name'] ?? 'unknown').
-                ' The model has no HubSpot ID (e.g. '.config('hubspot.company_id_column', 'hubspot_id').') set.'
-            );
+            Log::info('HubSpot ID missing on company update, creating instead', [
+                'name' => $this->modelData['name'] ?? 'unknown',
+                'model_id' => $this->modelData['id'] ?? null,
+            ]);
+
+            $this->createCompany();
+
+            return;
         }
 
         $properties = $this->buildUpdatePropertiesObject($this->modelData['hubspotMap'] ?? []);

--- a/src/Observers/HubspotCompanyObserver.php
+++ b/src/Observers/HubspotCompanyObserver.php
@@ -34,7 +34,7 @@ class HubspotCompanyObserver
             return;
         }
 
-        $this->dispatchSyncJob($model, 'update');
+        $this->dispatchSyncJob($model, $this->syncOperation($model));
     }
 
     /**
@@ -68,9 +68,15 @@ class HubspotCompanyObserver
             return false;
         }
 
-        $hubspotFields = array_values($model->getHubspotMap());
+        $ignoredFields = method_exists($model, 'getHubspotSyncIgnoredFields')
+            ? $model->getHubspotSyncIgnoredFields()
+            : [];
 
-        // Check if any HubSpot-mapped fields have changed
+        $hubspotFields = array_values(array_diff(
+            $model->getHubspotMap(),
+            $ignoredFields,
+        ));
+
         foreach ($hubspotFields as $field) {
             if ($model->wasChanged($field)) {
                 return true;
@@ -78,6 +84,18 @@ class HubspotCompanyObserver
         }
 
         return false;
+    }
+
+    /**
+     * Prefer create when the model has no HubSpot ID yet.
+     */
+    protected function syncOperation(Model $model): string
+    {
+        if ($model instanceof HubspotModelInterface && empty($model->getHubspotId())) {
+            return 'create';
+        }
+
+        return 'update';
     }
 
     /**

--- a/src/Observers/HubspotContactObserver.php
+++ b/src/Observers/HubspotContactObserver.php
@@ -35,7 +35,7 @@ class HubspotContactObserver
             return;
         }
 
-        $this->dispatchSyncJob($model, 'update');
+        $this->dispatchSyncJob($model, $this->syncOperation($model));
     }
 
     /**
@@ -69,9 +69,15 @@ class HubspotContactObserver
             return false;
         }
 
-        $hubspotFields = array_values($model->getHubspotMap());
+        $ignoredFields = method_exists($model, 'getHubspotSyncIgnoredFields')
+            ? $model->getHubspotSyncIgnoredFields()
+            : [];
 
-        // Check if any HubSpot-mapped fields have changed
+        $hubspotFields = array_values(array_diff(
+            $model->getHubspotMap(),
+            $ignoredFields,
+        ));
+
         foreach ($hubspotFields as $field) {
             if ($model->wasChanged($field)) {
                 return true;
@@ -79,6 +85,19 @@ class HubspotContactObserver
         }
 
         return false;
+    }
+
+    /**
+     * Prefer create when the model has no HubSpot ID yet so a follow-up
+     * mapped-field save (e.g. last login) does not queue a doomed update.
+     */
+    protected function syncOperation(Model $model): string
+    {
+        if ($model instanceof HubspotModelInterface && empty($model->getHubspotId())) {
+            return 'create';
+        }
+
+        return 'update';
     }
 
     /**

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -138,10 +138,16 @@ class HubspotContactService
     public function updateContact(array $data): array
     {
         if (empty($data['hubspot_id'])) {
-            throw new \Exception(
-                'HubSpot ID missing in model. Cannot update contact: '.($data['email'] ?? 'unknown').
-                ' The model has no HubSpot ID (e.g. '.config('hubspot.contact_id_column', 'hubspot_id').') set.'
-            );
+            $data = $this->hydrateHubspotIdFromModel($data);
+        }
+
+        if (empty($data['hubspot_id'])) {
+            Log::info('HubSpot ID missing on update, creating or finding contact instead', [
+                'email' => $data['email'] ?? 'unknown',
+                'model_id' => $data['id'] ?? null,
+            ]);
+
+            return $this->createContact($data, is_string($data['modelClass'] ?? null) ? $data['modelClass'] : '');
         }
 
         // Validate that the contact exists in HubSpot before attempting update
@@ -213,6 +219,37 @@ class HubspotContactService
             'id' => $hubspotContact->getId(),
             'properties' => $hubspotContact->getProperties() ?: [],
         ];
+    }
+
+    /**
+     * Reload hubspot_id from the local model when a queued update snapshot is stale.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function hydrateHubspotIdFromModel(array $data): array
+    {
+        $modelClass = is_string($data['modelClass'] ?? null) ? $data['modelClass'] : null;
+        $modelId = isset($data['id']) ? (int) $data['id'] : 0;
+
+        if ($modelId < 1 || $modelClass === null || $modelClass === '' || ! class_exists($modelClass)) {
+            return $data;
+        }
+
+        /** @var Model|null $model */
+        $model = $modelClass::query()->find($modelId);
+
+        if (! $model instanceof Model || ! method_exists($model, 'getHubspotId')) {
+            return $data;
+        }
+
+        $hubspotId = $model->getHubspotId();
+
+        if (is_string($hubspotId) && $hubspotId !== '') {
+            $data['hubspot_id'] = $hubspotId;
+        }
+
+        return $data;
     }
 
     /**
@@ -556,7 +593,7 @@ class HubspotContactService
         $model = $modelClass::find($modelId);
         if ($model instanceof Model && method_exists($model, 'setHubspotId')) {
             $model->setHubspotId($hubspotId);
-            $model->save();
+            $model->saveQuietly();
         }
     }
 

--- a/src/Traits/HubspotModelTrait.php
+++ b/src/Traits/HubspotModelTrait.php
@@ -29,6 +29,23 @@ trait HubspotModelTrait
     }
 
     /**
+     * Model fields that stay in `$hubspotMap` (so they still sync) but do not
+     * trigger an observer job when they are the only dirty attributes.
+     *
+     * @return list<string>
+     */
+    public function getHubspotSyncIgnoredFields(): array
+    {
+        $fields = $this->hubspotSyncIgnoredFields ?? [];
+
+        if (! is_array($fields)) {
+            return [];
+        }
+
+        return array_values(array_filter($fields, fn (mixed $field): bool => is_string($field) && $field !== ''));
+    }
+
+    /**
      * Get dynamic HubSpot properties for this model.
      */
     public function getHubspotProperties(array $hubspotMap): array

--- a/tests/Unit/HubspotContactServiceTest.php
+++ b/tests/Unit/HubspotContactServiceTest.php
@@ -255,6 +255,99 @@ test('it ignores unconfigured email map keys when collecting emails', function (
     expect($emails)->toBe(['login@example.com']);
 });
 
+test('it creates or finds a contact when update has no hubspot id', function () {
+    config(['hubspot.api_key' => 'dummy-key']);
+
+    $mockResponse = new SimplePublicObject;
+    $mockResponse->setId('12345');
+    $mockResponse->setProperties([
+        'email' => 'test@example.com',
+        'firstname' => 'John',
+        'lastname' => 'Doe',
+    ]);
+
+    $mockSearchResponse = Mockery::mock();
+    $mockSearchResponse->shouldReceive('getTotal')->andReturn(0);
+
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
+        ->once()
+        ->andReturn($mockSearchResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->create')
+        ->once()
+        ->andReturn($mockResponse);
+
+    $data = [
+        'id' => 1,
+        'email' => 'test@example.com',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'hubspotMap' => [
+            'email' => 'email',
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ];
+
+    $result = $this->service->updateContact($data);
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('12345');
+});
+
+test('it updates an existing contact when update has no hubspot id but email matches', function () {
+    config(['hubspot.api_key' => 'dummy-key']);
+
+    $existingContact = new SimplePublicObject;
+    $existingContact->setId('99999');
+    $existingContact->setProperties([
+        'email' => 'test@example.com',
+    ]);
+
+    $mockSearchResponse = Mockery::mock();
+    $mockSearchResponse->shouldReceive('getTotal')->andReturn(1);
+    $mockSearchResponse->shouldReceive('getResults')->andReturn([$existingContact]);
+
+    $mockUpdateResponse = new SimplePublicObject;
+    $mockUpdateResponse->setId('99999');
+    $mockUpdateResponse->setProperties([
+        'email' => 'test@example.com',
+        'firstname' => 'John',
+    ]);
+
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
+        ->once()
+        ->andReturn($mockSearchResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->getById')
+        ->with('99999')
+        ->andReturn(['id' => '99999']);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->update')
+        ->once()
+        ->with('99999', Mockery::any())
+        ->andReturn($mockUpdateResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
+
+    $data = [
+        'id' => 1,
+        'email' => 'test@example.com',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'hubspotMap' => [
+            'email' => 'email',
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ];
+
+    $result = $this->service->updateContact($data);
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('99999');
+});
+
 test('it updates contact successfully', function () {
     // Set a dummy API key to prevent initialization error
     config(['hubspot.api_key' => 'dummy-key']);

--- a/tests/Unit/Jobs/SyncHubspotContactJobTest.php
+++ b/tests/Unit/Jobs/SyncHubspotContactJobTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use HubSpot\Client\Crm\Contacts\Model\SimplePublicObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Jobs\SyncHubspotContactJob;
+use Tapp\LaravelHubspot\Models\HubspotContact;
 
 test('it creates contact when operation is create', function () {
     test()->skipIfNoRealApi();
@@ -140,7 +146,7 @@ test('it rebuilds the payload from the live model and treats a stored id as upda
         ],
     ]);
 
-    Illuminate\Support\Facades\Schema::create('hubspot_job_refresh_users', function (Illuminate\Database\Schema\Blueprint $table): void {
+    Schema::create('hubspot_job_refresh_users', function (Blueprint $table): void {
         $table->id();
         $table->string('email');
         $table->string('first_name')->nullable();
@@ -155,7 +161,7 @@ test('it rebuilds the payload from the live model and treats a stored id as upda
         'hubspot_id' => '99999',
     ]);
 
-    $mockResponse = new HubSpot\Client\Crm\Contacts\Model\SimplePublicObject;
+    $mockResponse = new SimplePublicObject;
     $mockResponse->setId('99999');
     $mockResponse->setProperties([
         'email' => 'fresh@example.com',
@@ -195,9 +201,9 @@ test('it rebuilds the payload from the live model and treats a stored id as upda
         ->and($job->modelData['email'])->toBe('fresh@example.com');
 });
 
-class HubspotJobRefreshUser extends Illuminate\Database\Eloquent\Model implements Tapp\LaravelHubspot\Contracts\HubspotModelInterface
+class HubspotJobRefreshUser extends Model implements HubspotModelInterface
 {
-    use Tapp\LaravelHubspot\Models\HubspotContact;
+    use HubspotContact;
 
     protected $table = 'hubspot_job_refresh_users';
 

--- a/tests/Unit/Jobs/SyncHubspotContactJobTest.php
+++ b/tests/Unit/Jobs/SyncHubspotContactJobTest.php
@@ -127,3 +127,87 @@ test('it skips execution when no api key is configured', function () {
 
     expect(fn () => $job->handle())->toThrow(Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
 });
+
+test('it rebuilds the payload from the live model and treats a stored id as update', function () {
+    config([
+        'hubspot.api_key' => 'dummy-key',
+        'hubspot.disabled' => false,
+        'database.default' => 'testing',
+        'database.connections.testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+    ]);
+
+    Illuminate\Support\Facades\Schema::create('hubspot_job_refresh_users', function (Illuminate\Database\Schema\Blueprint $table): void {
+        $table->id();
+        $table->string('email');
+        $table->string('first_name')->nullable();
+        $table->string('last_name')->nullable();
+        $table->string('hubspot_id')->nullable();
+    });
+
+    $user = HubspotJobRefreshUser::query()->create([
+        'email' => 'fresh@example.com',
+        'first_name' => 'Fresh',
+        'last_name' => 'User',
+        'hubspot_id' => '99999',
+    ]);
+
+    $mockResponse = new HubSpot\Client\Crm\Contacts\Model\SimplePublicObject;
+    $mockResponse->setId('99999');
+    $mockResponse->setProperties([
+        'email' => 'fresh@example.com',
+        'firstname' => 'Fresh',
+        'lastname' => 'User',
+    ]);
+
+    Tapp\LaravelHubspot\Facades\Hubspot::shouldReceive('crm->contacts->basicApi->getById')
+        ->with('99999')
+        ->andReturn(['id' => '99999']);
+
+    Tapp\LaravelHubspot\Facades\Hubspot::shouldReceive('crm->contacts->basicApi->update')
+        ->once()
+        ->with('99999', Mockery::any())
+        ->andReturn($mockResponse);
+
+    Tapp\LaravelHubspot\Facades\Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
+
+    $job = new SyncHubspotContactJob([
+        'id' => $user->id,
+        'hubspot_id' => null,
+        'email' => 'stale@example.com',
+        'first_name' => 'Stale',
+        'last_name' => 'User',
+        'hubspotMap' => [
+            'email' => 'email',
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ], 'update', HubspotJobRefreshUser::class);
+
+    $job->handle();
+
+    expect($job->operation)->toBe('update')
+        ->and($job->modelData['hubspot_id'])->toBe('99999')
+        ->and($job->modelData['first_name'])->toBe('Fresh')
+        ->and($job->modelData['email'])->toBe('fresh@example.com');
+});
+
+class HubspotJobRefreshUser extends Illuminate\Database\Eloquent\Model implements Tapp\LaravelHubspot\Contracts\HubspotModelInterface
+{
+    use Tapp\LaravelHubspot\Models\HubspotContact;
+
+    protected $table = 'hubspot_job_refresh_users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public array $hubspotMap = [
+        'email' => 'email',
+        'firstname' => 'first_name',
+        'lastname' => 'last_name',
+    ];
+}

--- a/tests/Unit/Observers/HubspotContactObserverTest.php
+++ b/tests/Unit/Observers/HubspotContactObserverTest.php
@@ -159,3 +159,53 @@ test('it includes dynamic properties from overridden hubspot properties method',
     expect($jobData['dynamicProperties']['courses_completed'])->toBe('3');
     expect($jobData['dynamicProperties']['last_course_access'])->toBe('2024-01-15');
 });
+
+test('it ignores mapped fields listed in hubspotSyncIgnoredFields', function () {
+    $model = new class extends Model implements HubspotModelInterface
+    {
+        use HubspotModelTrait;
+
+        public array $hubspotMap = [
+            'email' => 'email',
+            'app_last_login' => 'last_login',
+        ];
+
+        public array $hubspotSyncIgnoredFields = [
+            'last_login',
+        ];
+    };
+
+    $model->exists = true;
+    $model->email = 'test@example.com';
+    $model->last_login = null;
+    $model->syncOriginal();
+    $model->last_login = '2026-08-24 14:54:06';
+    $model->syncChanges();
+
+    $reflection = new ReflectionClass($this->observer);
+    $method = $reflection->getMethod('hasHubspotRelevantChanges');
+    $method->setAccessible(true);
+
+    expect($method->invoke($this->observer, $model))->toBeFalse();
+
+    $model->syncOriginal();
+    $model->email = 'updated@example.com';
+    $model->syncChanges();
+
+    expect($method->invoke($this->observer, $model))->toBeTrue();
+});
+
+test('it dispatches create when an update has no hubspot id', function () {
+    $model = new ContactObserverTestModel;
+    $model->hubspot_id = null;
+
+    $reflection = new ReflectionClass($this->observer);
+    $method = $reflection->getMethod('syncOperation');
+    $method->setAccessible(true);
+
+    expect($method->invoke($this->observer, $model))->toBe('create');
+
+    $model->hubspot_id = '12345';
+
+    expect($method->invoke($this->observer, $model))->toBe('update');
+});


### PR DESCRIPTION
## Summary
- Queued contact updates no longer throw when `hubspot_id` is missing: reload the id from the local model, or find/create by mapped emails.
- Jobs rebuild their payload from the live model before talking to HubSpot, so register-then-login snapshots cannot overwrite fresher data or fail after retries.
- Models can set `$hubspotSyncIgnoredFields` (e.g. `last_login`) so high-churn mapped fields stay in `$hubspotMap` but do not trigger a sync by themselves.
- Writing `hubspot_id` uses `saveQuietly()` so that write does not queue another observer job.

## Test plan
- [ ] Package unit tests (`vendor/bin/pest --group=unit`)
- [ ] Register a user that already exists in HubSpot and confirm `hubspot_id` is linked without a Nightwatch exception
- [ ] Login immediately after register and confirm no failed `SyncHubspotContactJob`
- [ ] Profile field change still queues an update; last-login-only save does not (once CHECK sets `$hubspotSyncIgnoredFields`)


Made with [Cursor](https://cursor.com)