### PR TITLE
Recover empty-ID contact updates via find-or-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `Laravel-Hubspot` will be documented in this file.
 
 ## Unreleased
 
+* Empty-ID `updateContact()` uses the same find-by-email-or-create recovery as invalid-ID (404), and still throws when there is no mapped email to search
+
 ## v2.4.0 - 2026-08-24
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The traits (`HubspotContact`, `HubspotCompany`) provide the implementation for t
 
 Optional: `$hubspotSyncIgnoredFields` (via `getHubspotSyncIgnoredFields()`) lists model attributes that remain in `$hubspotMap` but do not trigger an observer job on their own. Use this for high-churn fields such as `last_login`.
 
-If an update job runs before `hubspot_id` is written (register, then an immediate mapped-field save), the service reloads the id from the model or finds/creates the contact instead of throwing. Queued jobs also rebuild their payload from the live model before calling HubSpot, and writing `hubspot_id` uses `saveQuietly()` so that write does not queue another sync.
+If an update job runs before `hubspot_id` is written (register, then an immediate mapped-field save), the service reloads the id from the model or finds the contact by mapped email and updates it (or creates it when none exists). The missing-ID exception is only thrown when there is no mapped email to search. Queued jobs also rebuild their payload from the live model before calling HubSpot, and writing `hubspot_id` uses `saveQuietly()` so that write does not queue another sync.
 
 ### Company Model Setup
 

--- a/src/Services/HubspotContactService.php
+++ b/src/Services/HubspotContactService.php
@@ -142,12 +142,32 @@ class HubspotContactService
         }
 
         if (empty($data['hubspot_id'])) {
-            Log::info('HubSpot ID missing on update, creating or finding contact instead', [
-                'email' => $data['email'] ?? 'unknown',
-                'model_id' => $data['id'] ?? null,
-            ]);
+            $emailField = $this->getMappedEmailField($data);
+            if ($emailField) {
+                Log::info('HubSpot ID missing on update, finding contact by email', [
+                    'email' => $emailField,
+                    'model_id' => $data['id'] ?? null,
+                ]);
 
-            return $this->createContact($data, is_string($data['modelClass'] ?? null) ? $data['modelClass'] : '');
+                $contact = $this->findContact($data);
+                if ($contact) {
+                    $contactId = $contact['id'];
+                    $this->updateModelHubspotId($data['id'] ?? null, $contactId, $data['modelClass'] ?? null);
+                    $data['hubspot_id'] = $contactId;
+                } else {
+                    Log::info('HubSpot ID missing on update, no existing contact found by email, creating instead', [
+                        'email' => $emailField,
+                        'model_id' => $data['id'] ?? null,
+                    ]);
+
+                    return $this->createContact($data, $data['modelClass'] ?? '');
+                }
+            } else {
+                throw new \Exception(
+                    'HubSpot ID missing in model. Cannot update contact: '.($data['email'] ?? 'unknown').
+                    ' The model has no HubSpot ID (e.g. '.config('hubspot.contact_id_column', 'hubspot_id').') set.'
+                );
+            }
         }
 
         // Validate that the contact exists in HubSpot before attempting update

--- a/tests/Unit/HubspotContactServiceTest.php
+++ b/tests/Unit/HubspotContactServiceTest.php
@@ -1,8 +1,14 @@
 <?php
 
+use HubSpot\Client\Crm\Contacts\ApiException;
 use HubSpot\Client\Crm\Contacts\Model\SimplePublicObject;
 use HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInputForCreate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
 use Tapp\LaravelHubspot\Facades\Hubspot;
+use Tapp\LaravelHubspot\Models\HubspotContact;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
 
 beforeEach(function () {
@@ -270,7 +276,7 @@ test('it creates or finds a contact when update has no hubspot id', function () 
     $mockSearchResponse->shouldReceive('getTotal')->andReturn(0);
 
     Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
-        ->once()
+        ->twice()
         ->andReturn($mockSearchResponse);
 
     Hubspot::shouldReceive('crm->contacts->basicApi->create')
@@ -297,6 +303,13 @@ test('it creates or finds a contact when update has no hubspot id', function () 
 
 test('it updates an existing contact when update has no hubspot id but email matches', function () {
     config(['hubspot.api_key' => 'dummy-key']);
+
+    $user = createEmptyIdContactUser([
+        'email' => 'test@example.com',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'hubspot_id' => null,
+    ]);
 
     $existingContact = new SimplePublicObject;
     $existingContact->setId('99999');
@@ -331,7 +344,84 @@ test('it updates an existing contact when update has no hubspot id but email mat
     Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
 
     $data = [
+        'id' => $user->id,
+        'email' => 'test@example.com',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'modelClass' => HubspotEmptyIdContactUser::class,
+        'hubspotMap' => [
+            'email' => 'email',
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ];
+
+    $result = $this->service->updateContact($data);
+
+    expect($result)->toBeArray();
+    expect($result['id'])->toBe('99999');
+    expect($user->fresh()->hubspot_id)->toBe('99999');
+});
+
+test('it throws when update has no hubspot id and no mapped email', function () {
+    config(['hubspot.api_key' => 'dummy-key']);
+
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')->never();
+    Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
+    Hubspot::shouldReceive('crm->contacts->basicApi->update')->never();
+
+    $data = [
         'id' => 1,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'hubspotMap' => [
+            'firstname' => 'first_name',
+            'lastname' => 'last_name',
+        ],
+    ];
+
+    expect(fn () => $this->service->updateContact($data))
+        ->toThrow(Exception::class, 'HubSpot ID missing in model. Cannot update contact');
+});
+
+test('it finds by email and updates when hubspot id is invalid', function () {
+    config(['hubspot.api_key' => 'dummy-key']);
+
+    $existingContact = new SimplePublicObject;
+    $existingContact->setId('99999');
+    $existingContact->setProperties([
+        'email' => 'test@example.com',
+    ]);
+
+    $mockSearchResponse = Mockery::mock();
+    $mockSearchResponse->shouldReceive('getTotal')->andReturn(1);
+    $mockSearchResponse->shouldReceive('getResults')->andReturn([$existingContact]);
+
+    $mockUpdateResponse = new SimplePublicObject;
+    $mockUpdateResponse->setId('99999');
+    $mockUpdateResponse->setProperties([
+        'email' => 'test@example.com',
+        'firstname' => 'John',
+    ]);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->getById')
+        ->with('invalid-id')
+        ->andThrow(new ApiException('Not Found', 404));
+
+    Hubspot::shouldReceive('crm->contacts->searchApi->doSearch')
+        ->once()
+        ->andReturn($mockSearchResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->update')
+        ->once()
+        ->with('99999', Mockery::any())
+        ->andReturn($mockUpdateResponse);
+
+    Hubspot::shouldReceive('crm->contacts->basicApi->create')->never();
+
+    $data = [
+        'id' => 1,
+        'hubspot_id' => 'invalid-id',
         'email' => 'test@example.com',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -428,3 +518,47 @@ test('it skips execution when no api key is configured', function () {
     expect(fn () => $this->service->createContact($data, 'TestModel'))
         ->toThrow(Exception::class, 'HubSpot client not initialized. Please check your API key configuration.');
 });
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function createEmptyIdContactUser(array $attributes): HubspotEmptyIdContactUser
+{
+    config([
+        'database.default' => 'testing',
+        'database.connections.testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+    ]);
+
+    if (! Schema::hasTable('hubspot_empty_id_contact_users')) {
+        Schema::create('hubspot_empty_id_contact_users', function (Blueprint $table): void {
+            $table->id();
+            $table->string('email');
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('hubspot_id')->nullable();
+        });
+    }
+
+    return HubspotEmptyIdContactUser::query()->create($attributes);
+}
+
+class HubspotEmptyIdContactUser extends Model implements HubspotModelInterface
+{
+    use HubspotContact;
+
+    protected $table = 'hubspot_empty_id_contact_users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public array $hubspotMap = [
+        'email' => 'email',
+        'firstname' => 'first_name',
+        'lastname' => 'last_name',
+    ];
+}

--- a/tests/Unit/Models/HubspotContactTraitTest.php
+++ b/tests/Unit/Models/HubspotContactTraitTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Queue;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Jobs\SyncHubspotContactJob;
 use Tapp\LaravelHubspot\Models\HubspotContact;
 use Tapp\LaravelHubspot\Services\HubspotContactService;
 use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
@@ -141,4 +143,34 @@ test('updateOrCreateHubspotContact includes all required data', function () {
 
     expect($result)->toBeArray();
     expect($result['id'])->toBe('12345');
+});
+
+test('syncToHubSpot dispatches create when the model has no hubspot id', function () {
+    Queue::fake();
+    config([
+        'hubspot.queue.enabled' => true,
+        'hubspot.disabled' => false,
+    ]);
+
+    $this->model->setHubspotId(null);
+    $this->model->syncToHubSpot();
+
+    Queue::assertPushed(SyncHubspotContactJob::class, function (SyncHubspotContactJob $job): bool {
+        return $job->operation === 'create';
+    });
+});
+
+test('syncToHubSpot dispatches update when the model has a hubspot id', function () {
+    Queue::fake();
+    config([
+        'hubspot.queue.enabled' => true,
+        'hubspot.disabled' => false,
+    ]);
+
+    $this->model->setHubspotId('12345');
+    $this->model->syncToHubSpot();
+
+    Queue::assertPushed(SyncHubspotContactJob::class, function (SyncHubspotContactJob $job): bool {
+        return $job->operation === 'update';
+    });
 });

--- a/tests/Unit/Observers/HubspotContactObserverTest.php
+++ b/tests/Unit/Observers/HubspotContactObserverTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Queue;
 use Tapp\LaravelHubspot\Contracts\HubspotModelInterface;
+use Tapp\LaravelHubspot\Jobs\SyncHubspotContactJob;
 use Tapp\LaravelHubspot\Models\HubspotContact;
 use Tapp\LaravelHubspot\Observers\HubspotContactObserver;
 use Tapp\LaravelHubspot\Traits\HubspotModelTrait;
@@ -196,16 +198,49 @@ test('it ignores mapped fields listed in hubspotSyncIgnoredFields', function () 
 });
 
 test('it dispatches create when an update has no hubspot id', function () {
-    $model = new ContactObserverTestModel;
-    $model->hubspot_id = null;
+    Queue::fake();
+    config([
+        'hubspot.queue.enabled' => true,
+        'hubspot.disabled' => false,
+    ]);
 
-    $reflection = new ReflectionClass($this->observer);
-    $method = $reflection->getMethod('syncOperation');
-    $method->setAccessible(true);
+    $model = makeContactObserverUpdateModel(hubspotId: null);
 
-    expect($method->invoke($this->observer, $model))->toBe('create');
+    $this->observer->updated($model);
 
-    $model->hubspot_id = '12345';
-
-    expect($method->invoke($this->observer, $model))->toBe('update');
+    Queue::assertPushed(SyncHubspotContactJob::class, function (SyncHubspotContactJob $job): bool {
+        return $job->operation === 'create';
+    });
 });
+
+test('it dispatches update when an update has a hubspot id', function () {
+    Queue::fake();
+    config([
+        'hubspot.queue.enabled' => true,
+        'hubspot.disabled' => false,
+    ]);
+
+    $model = makeContactObserverUpdateModel(hubspotId: '12345');
+
+    $this->observer->updated($model);
+
+    Queue::assertPushed(SyncHubspotContactJob::class, function (SyncHubspotContactJob $job): bool {
+        return $job->operation === 'update';
+    });
+});
+
+function makeContactObserverUpdateModel(?string $hubspotId): ContactObserverTestModel
+{
+    $model = new ContactObserverTestModel;
+    $model->exists = true;
+    $model->id = 1;
+    $model->email = 'old@example.com';
+    $model->first_name = 'John';
+    $model->last_name = 'Doe';
+    $model->hubspot_id = $hubspotId;
+    $model->syncOriginal();
+    $model->email = 'new@example.com';
+    $model->syncChanges();
+
+    return $model;
+}


### PR DESCRIPTION
# Details

Queued `update` jobs for LMS users with a null `hubspot_id` threw immediately (`HubSpot ID missing in model`) even when the contact already existed in HubSpot and could be found by email. That is the same “LMS not linked” case as an ID HubSpot does not recognize (404).

`updateContact()` now uses the existing find-or-create path when `hubspot_id` is empty:

- Mapped email present and contact found: persist the ID via `updateModelHubspotId()`, then continue the normal PATCH
- Mapped email present and contact not found: `createContact()`
- No mapped email to search: still throw the missing-ID exception

`HubspotContactObserver::updated()` already dispatches `create` when the model has no ID and `update` when it does (same rule as `syncToHubSpot()`). Jobs already on the queue with `operation=update` and an empty ID still recover at the service.

Company sync is unchanged. The 404 email fallback is unchanged.

## Steps to test changes

1. Run `./vendor/bin/pest --group=unit`
2. Confirm empty-ID + existing email searches, persists `hubspot_id`, and PATCHes (no exception)
3. Confirm empty-ID + unknown email creates the contact
4. Confirm empty-ID + no mapped email still throws the missing-ID exception
5. Confirm an invalid HubSpot ID (404) still finds by email and updates
6. Confirm observer `updated()` and `syncToHubSpot()` dispatch `create` with no ID and `update` with an ID

## Issues Addressed

https://app.clickup.com/t/868kv6vvd

## Screenshots

N/A — package / backend sync change, no UI
